### PR TITLE
fix: 修复移动端设置面板缺失删除记忆按钮的问题

### DIFF
--- a/components/features/Settings/mobile/MobileSettingsModal.tsx
+++ b/components/features/Settings/mobile/MobileSettingsModal.tsx
@@ -78,6 +78,7 @@ interface Props {
     onSaveVisual: (config: 视觉设置结构) => void;
     onSaveGame?: (config: 游戏设置结构) => void;
     onSaveMemory?: (config: 记忆配置结构) => void;
+    onDeleteMemory?: (round: number) => void;
     onCreateNpc: (seed?: Partial<NPC结构>) => NPC结构 | void;
     onSaveNpc: (npcId: string, npc: NPC结构) => void;
     onDeleteNpc: (npcId: string) => void;
@@ -96,7 +97,7 @@ interface Props {
 const MobileSettingsModal: React.FC<Props> = ({
     activeTab, onTabChange, onClose,
     apiConfig, visualConfig, gameConfig, memoryConfig, prompts, festivals, currentTheme, history, memorySystem, socialList, runtimeState, currentStory, openingConfig, contextSnapshot,
-    onSaveApi, onSaveVisual, onSaveGame, onSaveMemory, onCreateNpc, onSaveNpc, onDeleteNpc, onStartNpcMemorySummary, onUploadNpcImage, onReplaceVariableSection, onApplyVariableCommand, onUpdatePrompts, onUpdateFestivals, onThemeChange,
+    onSaveApi, onSaveVisual, onSaveGame, onSaveMemory, onDeleteMemory, onCreateNpc, onSaveNpc, onDeleteNpc, onStartNpcMemorySummary, onUploadNpcImage, onReplaceVariableSection, onApplyVariableCommand, onUpdatePrompts, onUpdateFestivals, onThemeChange,
     onReturnToHome, isHome, requestConfirm
 }) => {
     const tabItems = [
@@ -187,7 +188,7 @@ const MobileSettingsModal: React.FC<Props> = ({
         }
         if (activeTab === 'music') return <MusicSettings />;
         if (activeTab === 'storage') return <StorageManager requestConfirm={requestConfirm} />;
-        if (activeTab === 'history') return <HistoryViewer history={history} memorySystem={memorySystem} />;
+        if (activeTab === 'history') return <HistoryViewer history={history} memorySystem={memorySystem} onDeleteMemory={onDeleteMemory} />;
         if (activeTab === 'logs') return <LogViewer />;
         if (activeTab === 'context' && contextSnapshot) {
             return (


### PR DESCRIPTION
桌面端 SettingsModal 已正确传递 onDeleteMemory 给 HistoryViewer，
但移动端 MobileSettingsModal 遗漏了该属性的传递，
导致手机用户在"互动历史"中展开记忆后看不到红色的"删除此记忆"按钮。
把移动端没按钮的问题修了一下
修改内容（MobileSettingsModal.tsx）：
- Props 接口新增 onDeleteMemory
- 组件解构新增 onDeleteMemory
- HistoryViewer 调用时传入 onDeleteMemory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 移动设置界面中的历史记录选项卡现已支持删除功能，用户可以删除特定的历史记录条目。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ypq123456789/MoRanJiangHu/pull/3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->