### PR TITLE
fix: reduce online presence heartbeat jank

### DIFF
--- a/services/onlinePresence.ts
+++ b/services/onlinePresence.ts
@@ -1,6 +1,6 @@
 import { RELEASE_INFO } from '../data/releaseInfo';
 import { isNativeCapacitorEnvironment } from '../utils/nativeRuntime';
-import { 获取本地图片图床迁移状态, 读取本地图片资源统计 } from './dbService';
+import { 获取本地图片图床迁移状态 } from './dbService';
 
 const ONLINE_SESSION_ID_KEY = 'moranjianghu.onlineSessionId';
 const HEARTBEAT_PATH = '/api/admin/online';
@@ -31,10 +31,7 @@ const readSessionId = (): string => {
     }
 };
 
-const buildHeartbeatPayload = async (sessionId: string) => {
-    const imageStats = await 读取本地图片资源统计().catch(() => ({
-        migrationStatus: 获取本地图片图床迁移状态()
-    }));
+const buildHeartbeatPayload = (sessionId: string) => {
     return {
         sessionId,
         path: `${window.location.pathname}${window.location.search}`.slice(0, 240),
@@ -42,7 +39,9 @@ const buildHeartbeatPayload = async (sessionId: string) => {
         versionName: RELEASE_INFO.versionName,
         versionCode: RELEASE_INFO.versionCode,
         platform: isNativeCapacitorEnvironment() ? 'capacitor-android' : 'web',
-        imageStats
+        imageStats: {
+            migrationStatus: 获取本地图片图床迁移状态()
+        }
     };
 };
 
@@ -52,7 +51,7 @@ const sendHeartbeat = async (sessionId: string): Promise<void> => {
         headers: {
             'Content-Type': 'application/json'
         },
-        body: JSON.stringify(await buildHeartbeatPayload(sessionId)),
+        body: JSON.stringify(buildHeartbeatPayload(sessionId)),
         keepalive: true,
         cache: 'no-store'
     }).catch(() => undefined);
@@ -102,7 +101,7 @@ export const startOnlinePresenceHeartbeat = (): (() => void) => {
         try {
             socket.send(JSON.stringify({
                 type,
-                ...(await buildHeartbeatPayload(sessionId))
+                ...buildHeartbeatPayload(sessionId)
             }));
         } catch {
             // HTTP heartbeat remains as a fallback.
@@ -145,6 +144,7 @@ export const startOnlinePresenceHeartbeat = (): (() => void) => {
 
     const tick = () => {
         if (stopped) return;
+        if (socket && socket.readyState === WebSocket.OPEN) return;
         void sendHeartbeat(sessionId);
     };
 


### PR DESCRIPTION
## 修改内容
- 在线心跳不再每次全量读取本地图片资源统计，避免周期性扫描 IndexedDB 存档、设置和图片资源。
- 心跳 payload 保留轻量图片迁移状态，在线统计仍可知道迁移阶段。
- WebSocket 已连接时跳过备用 HTTP 心跳，避免双路心跳重复占用前台资源。

## 验证
- npm.cmd run build 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化在线存在心跳的数据构建与发送策略，简化了异步逻辑。
  * 当 WebSocket 连接可用时，避免发送冗余的 HTTP 心跳请求。
  * 改进了心跳负载中图片迁移状态的数据填充机制。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ypq123456789/MoRanJiangHu/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->