### PR TITLE
fix: 修复旁白右引号被换到下一行的问题fix narrator quote line break

### DIFF
--- a/components/features/Chat/MessageRenderers.tsx
+++ b/components/features/Chat/MessageRenderers.tsx
@@ -344,10 +344,10 @@ const 格式化旁白断行 = (value: string): string => {
 
 export const NarratorRenderer: React.FC<{ text: string; visualConfig?: 视觉设置结构 }> = ({ text, visualConfig }) => {
     const style = 构建区域文字样式(visualConfig, '旁白');
-    const displayText = useMemo(() => 格式化旁白断行(text), [text]);
+    const displayText = useMemo(() => 格式化旁白断行(text).replace(/\n([”」』》）】])/g, '$1'), [text]);
     return (
         <div className="narrator-renderer w-full my-1 px-8 py-2 bg-white/5 backdrop-blur-sm border-x-4 border-wuxia-gold/55 leading-relaxed relative overflow-hidden rounded-md shadow-lg transition-all duration-300" style={style}>
-            <p className="relative z-10 whitespace-pre-wrap break-words tracking-wide" style={{ fontSize: 'inherit', lineHeight: 'inherit' }}>{displayText}</p>
+            <p className="relative z-10 whitespace-pre-wrap break-normal [word-break:normal] [overflow-wrap:break-word] [line-break:strict] tracking-wide" style={{ fontSize: 'inherit', lineHeight: 'inherit' }}>{displayText}</p>
         </div>
     );
 };


### PR DESCRIPTION
修复剧情旁白文本中，中文右引号 `”` 在格式化断行后被单独换到下一行的问题。

变更内容：
- 在 NarratorRenderer 中对格式化后的旁白文本增加清理
- 将换行后的中文右引号合并回上一行
- 避免右引号单独出现在下一行

测试：
- 本地运行 `npm run dev`
- 本地运行 `npm run build`
- 确认原先右引号单独换行的问题已修复

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了旁白文本的换行显示，减少在引号和括号后的不必要换行
  * 优化了段落文本的换行控制，提供更精细和美观的文本排版效果

<!-- end of auto-generated comment: release notes by coderabbit.ai -->