### PR TITLE
fix: 修复无标签旁白被误识别为角色对话的问题

### DIFF
--- a/__tests__/dialogueLogNormalizer.bracket.test.ts
+++ b/__tests__/dialogueLogNormalizer.bracket.test.ts
@@ -1,0 +1,21 @@
+import { 规范化对白日志 } from '../utils/dialogueLogNormalizer';
+import { describe, test, expect } from 'vitest';
+
+describe('dialogueLogNormalizer bracket tests', () => {
+  test('unlabeled quoted sentence remains narration', () => {
+    const input = [
+      { sender: '旁白', text: '吴杰涛的手猛地一抖……\n“我操……”' }
+    ];
+    const out = 规范化对白日志(input);
+    expect(out.some(item => item.sender !== '旁白')).toBe(false);
+    expect(out.some(item => (item.text || '').includes('我操'))).toBe(true);
+  });
+
+  test('bracketed speaker produces dialogue', () => {
+    const input = [
+      { sender: '旁白', text: '【吴杰涛】“我操……”' }
+    ];
+    const out = 规范化对白日志(input);
+    expect(out.some(item => item.sender === '吴杰涛' && (item.text || '').includes('我操'))).toBe(true);
+  });
+});

--- a/__tests__/dialogueLogNormalizer.test.ts
+++ b/__tests__/dialogueLogNormalizer.test.ts
@@ -36,15 +36,18 @@ describe('dialogueLogNormalizer story readability cleanup', () => {
         expect(logs[0].text).toContain('\n\n');
     });
 
-    it('keeps quoted dialogue from narration renderable as character bubbles', () => {
+    it('keeps quoted dialogue from narration as narration without bracket labels', () => {
         const logs = 规范化可渲染对白日志([{
             sender: '旁白',
             text: '杨培强停下手里的动作。一个清冷的女声从侧后方传来。俞月荷正站在门边，低声说道：“你动作能不能轻一点？如果里面装的是玻璃安瓿瓶，你刚才那一下，至少报废了我们半个月的口粮。”'
         }] as any);
-        expect(logs.some((item: any) => item.sender === '俞月荷' && item.text.includes('动作能不能轻一点'))).toBe(true);
+        expect(logs).toEqual([{
+            sender: '旁白',
+            text: '杨培强停下手里的动作。一个清冷的女声从侧后方传来。俞月荷正站在门边，低声说道：“你动作能不能轻一点？如果里面装的是玻璃安瓿瓶，你刚才那一下，至少报废了我们半个月的口粮。”'
+        }]);
     });
 
-    it('protects line breaks inside quoted dialogue before detecting character bubbles', () => {
+    it('protects line breaks inside quoted narration without inferring speaker', () => {
         const logs = 规范化可渲染对白日志([{
             sender: '旁白',
             text: [
@@ -56,33 +59,31 @@ describe('dialogueLogNormalizer story readability cleanup', () => {
 
         expect(logs).toEqual([
             {
-                sender: '叶青',
-                text: '先别兑换，确认任务世界和限制条件。如果主神限制热武器，我们就换侦查能力。'
+                sender: '旁白',
+                text: '叶青压低声音说道：“先别兑换，确认任务世界和限制条件。如果主神限制热武器，我们就换侦查能力。”'
             }
         ]);
     });
 
-    it('merges adjacent log entries when an opening quote was split across logs', () => {
+    it('merges adjacent narration entries when an opening quote was split across logs', () => {
         const logs = 规范化可渲染对白日志([
             { sender: '旁白', text: '叶青压低声音说道：“先别兑换，' },
             { sender: '旁白', text: '确认任务世界和限制条件。”她看向主神光球。' }
         ] as any);
 
         expect(logs).toEqual([
-            { sender: '叶青', text: '先别兑换，确认任务世界和限制条件。' },
-            { sender: '旁白', text: '她看向主神光球。' }
+            { sender: '旁白', text: '叶青压低声音说道：“先别兑换，确认任务世界和限制条件。”她看向主神光球。' }
         ]);
     });
 
-    it('does not include action tails in inferred speaker names', () => {
+    it('does not infer speaker names from action tails', () => {
         const logs = 规范化可渲染对白日志([
             { sender: '旁白', text: '叶青点点头说道：“我去检查补给箱，' },
             { sender: '旁白', text: '看看有没有止血喷雾。”白光重新稳定。' }
         ] as any);
 
         expect(logs).toEqual([
-            { sender: '叶青', text: '我去检查补给箱，看看有没有止血喷雾。' },
-            { sender: '旁白', text: '白光重新稳定。' }
+            { sender: '旁白', text: '叶青点点头说道：“我去检查补给箱，看看有没有止血喷雾。”白光重新稳定。' }
         ]);
     });
 
@@ -103,7 +104,7 @@ describe('dialogueLogNormalizer story readability cleanup', () => {
         ]);
     });
 
-    it('splits bare colon speaker lines from old narration into character bubbles', () => {
+    it('keeps bare colon speaker lines from old narration as narration', () => {
         const logs = 规范化可渲染对白日志([{
             sender: '旁白',
             text: [
@@ -114,9 +115,7 @@ describe('dialogueLogNormalizer story readability cleanup', () => {
         }] as any);
 
         expect(logs).toEqual([
-            { sender: '旁白', text: '门外有人走来。' },
-            { sender: '林婉儿', text: '我也看到这个bug了，有些角色说话的时候对话框就没了。' },
-            { sender: '旁白', text: '她抬头看你。' }
+            { sender: '旁白', text: '门外有人走来。\n林婉儿（皱眉）：我也看到这个bug了，有些角色说话的时候对话框就没了。\n她抬头看你。' }
         ]);
     });
 
@@ -146,7 +145,7 @@ describe('dialogueLogNormalizer story readability cleanup', () => {
         ]);
     });
 
-    it('keeps bare colon protocol labels as narration', () => {
+    it('keeps all bare colon lines as narration', () => {
         const logs = 规范化可渲染对白日志([{
             sender: '旁白',
             text: [
@@ -157,8 +156,7 @@ describe('dialogueLogNormalizer story readability cleanup', () => {
         }] as any);
 
         expect(logs).toEqual([
-            { sender: '旁白', text: '地点：杨家堡后院\n任务：检查对话框' },
-            { sender: '林婉儿', text: '真正的对白才需要头像。' }
+            { sender: '旁白', text: '地点：杨家堡后院\n任务：检查对话框\n林婉儿：真正的对白才需要头像。' }
         ]);
     });
 
@@ -201,16 +199,19 @@ describe('dialogueLogNormalizer story readability cleanup', () => {
         ]);
     });
 
-    it('only promotes unlabeled follow-up lines when they look like oral speech', () => {
+    it('does not promote unlabeled follow-up lines that look like oral speech', () => {
         const oral = 规范化可渲染对白日志([{
             sender: '旁白',
             text: '俞月荷冷笑一声，将表格拍在桌上。\n三百点？你真觉得这点贡献够换一整箱药？'
         }] as any);
 
-        expect(oral.some((item: any) => item.sender === '俞月荷' && item.text.includes('三百点'))).toBe(true);
+        expect(oral).toEqual([{
+            sender: '旁白',
+            text: '俞月荷冷笑一声，将表格拍在桌上。\n三百点？你真觉得这点贡献够换一整箱药？'
+        }]);
     });
 
-    it('promotes quoted oral speech after voice and gaze cues without explicit said tags', () => {
+    it('keeps quoted oral speech after voice and gaze cues as narration without bracket labels', () => {
         const logs = 规范化可渲染对白日志([{
             sender: '旁白',
             text: [
@@ -220,7 +221,21 @@ describe('dialogueLogNormalizer story readability cleanup', () => {
             ].join('\n\n')
         }] as any);
 
-        expect(logs.some((item: any) => item.sender === '秦映雪' && item.text.includes('制式消音器'))).toBe(true);
-        expect(logs.some((item: any) => item.sender === '秦映雪' && item.text.includes('如果你觉得这玩意儿'))).toBe(true);
+        expect(logs).toHaveLength(1);
+        expect(logs[0].sender).toBe('旁白');
+        expect(logs[0].text).toContain('制式消音器');
+        expect(logs[0].text).toContain('如果你觉得这玩意儿');
+    });
+
+    it('keeps unlabeled quoted exclamations as narration', () => {
+        const logs = 规范化可渲染对白日志([{
+            sender: '旁白',
+            text: '吴杰涛的手猛地一抖……\n“我操……”'
+        }] as any);
+
+        expect(logs).toEqual([{
+            sender: '旁白',
+            text: '吴杰涛的手猛地一抖……\n“我操……”'
+        }]);
     });
 });

--- a/__tests__/storyResponseParser.test.ts
+++ b/__tests__/storyResponseParser.test.ts
@@ -87,7 +87,7 @@ describe('storyResponseParser', () => {
         ]);
     });
 
-    it('splits quoted dialogue embedded in narrator lines into character logs', () => {
+    it('keeps quoted dialogue embedded in narrator lines as narration without bracket labels', () => {
         const parsed = parseStoryRawText([
             '<正文>',
             '【旁白】晨风卷过演武场，杨镇远负手站在石阶前，沉声道：“剑势散了，脚下也浮。再走一遍。”',
@@ -97,11 +97,10 @@ describe('storyResponseParser', () => {
         ].join('\n'));
 
         expect(parsed.logs).toEqual([
-            { sender: '旁白', text: '晨风卷过演武场，杨镇远负手站在石阶前' },
-            { sender: '杨镇远', text: '剑势散了，脚下也浮。再走一遍。' },
-            { sender: '旁白', text: '杨培强收剑回身' },
-            { sender: '杨培强', text: '侄儿明白。' },
-            { sender: '旁白', text: '杨镇远点了点头，目光仍落在剑尖上。' }
+            {
+                sender: '旁白',
+                text: '晨风卷过演武场，杨镇远负手站在石阶前，沉声道：“剑势散了，脚下也浮。再走一遍。”\n杨培强收剑回身，说道：“侄儿明白。”杨镇远点了点头，目光仍落在剑尖上。'
+            }
         ]);
     });
 
@@ -151,7 +150,7 @@ describe('storyResponseParser', () => {
         ]);
     });
 
-    it('parses bare colon speaker lines as dialogue turns', () => {
+    it('keeps bare colon speaker lines as narration', () => {
         const parsed = parseStoryRawText([
             '<正文>',
             '林婉儿：我也看到这个bug了，有些角色说话的时候对话框就没了。',
@@ -160,11 +159,11 @@ describe('storyResponseParser', () => {
         ].join('\n'), { validateDialogueFormat: true });
 
         expect(parsed.logs).toEqual([
-            { sender: '林婉儿', text: '我也看到这个bug了，有些角色说话的时候对话框就没了。' }
+            { sender: '旁白', text: '林婉儿：我也看到这个bug了，有些角色说话的时候对话框就没了。' }
         ]);
     });
 
-    it('parses colon speaker lines with action hints without promoting protocol labels', () => {
+    it('keeps colon speaker lines with action hints as narration', () => {
         const parsed = parseStoryRawText([
             '<正文>',
             '地点：杨家堡后院',
@@ -175,19 +174,23 @@ describe('storyResponseParser', () => {
         ].join('\n'), { validateDialogueFormat: true });
 
         expect(parsed.logs).toEqual([
-            { sender: '旁白', text: '地点：杨家堡后院\n任务：检查对话框' },
-            { sender: '林婉儿', text: '真正的对白才需要头像。' }
+            { sender: '旁白', text: '地点：杨家堡后院\n任务：检查对话框\n林婉儿（皱眉）：真正的对白才需要头像。' }
         ]);
     });
 
-    it('still rejects likely unlabeled oral dialogue during strict parsing', () => {
-        expect(() => parseStoryRawText([
+    it('keeps likely unlabeled oral dialogue during strict parsing', () => {
+        const parsed = parseStoryRawText([
             '<正文>',
             '俞月荷冷笑一声，将表格拍在桌上。',
             '三百点？你真觉得这点贡献够换一整箱药？',
             '</正文>',
             '<短期记忆>俞月荷质疑贡献兑换。</短期记忆>'
-        ].join('\n'), { validateDialogueFormat: true })).toThrow(/疑似角色「俞月荷」/);
+        ].join('\n'), { validateDialogueFormat: true });
+
+        expect(parsed.logs).toEqual([{
+            sender: '旁白',
+            text: '俞月荷冷笑一声，将表格拍在桌上。\n三百点？你真觉得这点贡献够换一整箱药？'
+        }]);
     });
 
     it('keeps only fully quoted single-speaker text as character bubbles for rendering', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "墨色江湖---无尽武林",
-  "version": "1.0.403",
+  "version": "1.0.408",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "墨色江湖---无尽武林",
-      "version": "1.0.403",
+      "version": "1.0.408",
       "dependencies": {
         "@capacitor/android": "^8.3.1",
         "@capacitor/app": "^8.1.0",

--- a/services/ai/storyResponseParser.ts
+++ b/services/ai/storyResponseParser.ts
@@ -663,17 +663,11 @@ const 正文冒号说话人排除集合 = new Set([
     '基础', '环境', '状态', '幸运', '装备', '结果', '奖励', '获得', '失去'
 ]);
 
-const 解析无括号正文发送者行 = (line: string): { sender: string; text: string } | null => {
-    const match = (line || '').trim().match(/^([A-Za-z][A-Za-z0-9_· -]{1,23}|[\u4e00-\u9fff]{2,4})(?:[（(][^）)\n]{1,16}[）)])?\s*[:：]\s*(.+)$/u);
-    if (!match) return null;
-    const sender = 规范化日志发送者(match[1] || '');
-    if (!sender) return null;
-    if (正文冒号说话人排除集合.has(sender)) return null;
-    if (!是否可信正文标签发送者(sender, { allowUnknownName: true })) return null;
-    return {
-        sender,
-        text: (match[2] || '').trim()
-    };
+const 解析无括号正文发送者行 = (_line: string): { sender: string; text: string } | null => {
+    // Disabled: only explicit bracketed speakers 【角色名】 are allowed to mark dialogue.
+    // Treat bare-colon lines (如 `角色: 文本`) as narration. Return null to prevent
+    // implicit speaker extraction.
+    return null;
 };
 
 const 解析判定日志行 = (line: string): { sender: string; text: string; trailingBody?: string } | null => {
@@ -885,23 +879,8 @@ const 是否像无标签口语行 = (line: string): boolean => {
     return 无标签口语起始正则.test(text) || /[？?！!]$/.test(text) || /(?:吧|吗|呢|啊|罢|了)$/.test(text);
 };
 
-const 检测正文对白格式问题 = (body: string): string | null => {
-    const lines = (body || '')
-        .replace(/\r\n/g, '\n')
-        .split('\n')
-        .map(line => line.trim())
-        .filter(Boolean)
-        .filter(line => !是否判定日志文本(line));
-    if (lines.length < 2) return null;
-    if (lines.some(line => /^【\s*[^】]+?\s*】/.test(line))) return null;
-
-    for (let index = 0; index < lines.length - 1; index += 1) {
-        const speaker = 提取无标签动作行人物名(lines[index]);
-        if (speaker && 是否像无标签口语行(lines[index + 1])) {
-            return `疑似角色「${speaker}」的对白没有使用【角色名】标签`;
-        }
-    }
-    return null;
+const 检测正文对话格式问题 = (_body: string): string | null => {
+  return null;
 };
 
 const 清理命令尾部分隔符 = (source: string): string => {
@@ -1300,7 +1279,7 @@ const 解析标签协议响应 = (content: string, options?: Required<StoryParse
         .join('\n\n');
 
     const dialogueFormatIssue = options?.validateDialogueFormat
-        ? 检测正文对白格式问题(bodyJudgeExtraction.cleanBody)
+        ? 检测正文对话格式问题(bodyJudgeExtraction.cleanBody)
         : null;
     if (dialogueFormatIssue) {
         throw new StoryResponseParseError(

--- a/tests/story-response-dialogue-recovery.test.ts
+++ b/tests/story-response-dialogue-recovery.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { parseStoryRawText } from '../services/ai/storyResponseParser';
 
 describe('开局正文对白兜底恢复', () => {
-    it('主剧情严格模式检测到无标签台词时触发重试错误', () => {
+    it('主剧情严格模式不再根据无标签口语触发重试错误', () => {
         const raw = `
 <正文>
 俞月荷将长剑归鞘，发出“咔”的一声轻响。
@@ -11,10 +11,14 @@ describe('开局正文对白兜底恢复', () => {
 <短期记忆>开局。</短期记忆>
 `;
 
-        expect(() => parseStoryRawText(raw, { validateDialogueFormat: true })).toThrow('对白没有使用【角色名】标签');
+        const parsed = parseStoryRawText(raw, { validateDialogueFormat: true });
+        expect(parsed.logs).toEqual([{
+            sender: '旁白',
+            text: '俞月荷将长剑归鞘，发出“咔”的一声轻响。\n我们昨天打听到的消息，万宝商会的飞舟后天就会途经苍龙岭。如果我们想搭乘飞舟去中州，今天必须凑齐足够的下品灵石。'
+        }]);
     });
 
-    it('把无角色标签但紧邻人物动作的口语段恢复成对话框日志', () => {
+    it('把无角色标签但紧邻人物动作的口语段保留为旁白', () => {
         const raw = `
 <正文>
 俞月荷将长剑归鞘，发出“咔”的一声轻响。
@@ -27,10 +31,10 @@ describe('开局正文对白兜底恢复', () => {
 
         const parsed = parseStoryRawText(raw);
         expect(parsed.logs).toEqual([
-            { sender: '旁白', text: '俞月荷将长剑归鞘，发出“咔”的一声轻响。' },
-            { sender: '俞月荷', text: '我们昨天打听到的消息，万宝商会的飞舟后天就会途经苍龙岭。如果我们想搭乘飞舟去中州，今天必须凑齐足够的下品灵石。' },
-            { sender: '旁白', text: '杨培强走到桌旁，给自己倒了一杯昨夜剩下的冷茶。' },
-            { sender: '杨培强', text: '昨天在黑市，我看到有人悬赏一株蛇涎草，价格刚好是三十块下品灵石。地点就在苍龙岭外围的瘴气林。' }
+            {
+                sender: '旁白',
+                text: '俞月荷将长剑归鞘，发出“咔”的一声轻响。\n我们昨天打听到的消息，万宝商会的飞舟后天就会途经苍龙岭。如果我们想搭乘飞舟去中州，今天必须凑齐足够的下品灵石。\n杨培强走到桌旁，给自己倒了一杯昨夜剩下的冷茶。\n昨天在黑市，我看到有人悬赏一株蛇涎草，价格刚好是三十块下品灵石。地点就在苍龙岭外围的瘴气林。'
+            }
         ]);
     });
 

--- a/utils/dialogueLogNormalizer.ts
+++ b/utils/dialogueLogNormalizer.ts
@@ -247,7 +247,7 @@ const 是否像引号对白内容 = (text: string): boolean => {
 
 const 人物动作动词正则 = /^(?:将|把|给|向|对|朝|走|站|坐|停|回|转|看|望|抬|低|点|摇|皱|叹|笑|冷笑|苦笑|轻笑|沉|伸|握|按|收|拔|举|放|推|扶|拂|敛|挑|倒|取|递|开口|提醒|解释|说道|说|道|问|答)/;
 const 无标签言语引导正则 = /^(.{1,32}?)(?:说|说道|道|问|问道|喊|喊道|喝|喝道|答|答道|回|回道|唤|唤道|骂|骂道|笑|笑道|叹|叹道|吩咐|提醒|解释|应|应道|接|接道|开口|继续|补充|又道)\s*[：:，,]\s*(.{2,500})$/;
-const 方括号说话人行正则 = /^[【\[]\s*([A-Za-z0-9_\u4e00-\u9fff·]{1,16})\s*[】\]]\s*(.{1,800})$/;
+const 方括号说话人行正则 = /^【\s*([A-Za-z0-9_\u4e00-\u9fff·]{1,16})\s*】\s*(.{1,800})$/;
 const 裸冒号说话人行正则 = /^([A-Za-z][A-Za-z0-9_· -]{1,23}|[\u4e00-\u9fff]{2,4})(?:[（(][^）)\n]{1,16}[）)])?\s*[:：]\s*(.{1,800})$/u;
 const 裸冒号非对白标签集合 = new Set([
     '地点', '时间', '天气', '任务', '命令', '短期记忆', '中期记忆', '长期记忆', '即时记忆',
@@ -409,7 +409,6 @@ const 拆分旁白夹杂无标签对白 = (log: GameLog): GameLog[] => {
     if (!source || !source.includes('\n')) return [log];
 
     const result: GameLog[] = [];
-    let pendingSpeaker = '';
     for (const rawLine of source.split('\n')) {
         const line = rawLine.trim();
         if (!line) continue;
@@ -429,42 +428,13 @@ const 拆分旁白夹杂无标签对白 = (log: GameLog): GameLog[] => {
                 && !拟声词正则.test(speech)
             ) {
                 result.push({ sender: bracketSpeakerName, text: speech });
-                pendingSpeaker = bracketSpeakerName;
                 continue;
             }
         }
-
-        const colonSpeaker = line.match(裸冒号说话人行正则);
-        const colonSpeakerName = 清理说话人(colonSpeaker?.[1] || '');
-        const colonSpeech = (colonSpeaker?.[2] || '').trim();
-        if (
-            colonSpeaker
-            && colonSpeakerName
-            && !裸冒号非对白标签集合.has(colonSpeakerName)
-            && colonSpeech
-            && !拟声词正则.test(colonSpeech)
-        ) {
-            result.push({ sender: colonSpeakerName, text: colonSpeech });
-            pendingSpeaker = colonSpeakerName;
-            continue;
-        }
-
-        const guided = line.match(无标签言语引导正则);
-        const guidedSpeaker = 清理说话人(guided?.[1] || '');
-        if (guided && guidedSpeaker) {
-            result.push({ sender: guidedSpeaker, text: (guided[2] || '').trim() });
-            pendingSpeaker = guidedSpeaker;
-            continue;
-        }
-
-        if (pendingSpeaker && 是否像无标签口语(line)) {
-            result.push({ sender: pendingSpeaker, text: line });
-            pendingSpeaker = '';
-            continue;
-        }
-
+        // Only explicit bracketed speakers are treated as character lines.
+        // All other forms (colon labels, implied/guided lines, or unlabeled speech)
+        // are considered narration.
         result.push({ sender: '旁白', text: line });
-        pendingSpeaker = 提取动作行说话人(line);
     }
 
     return result.length > 1 ? 合并相邻同发送者(result) : [log];
@@ -580,22 +550,14 @@ const 拆分旁白夹杂对白 = (log: GameLog, knownSpeakers: string[]): GameLo
         const quoteEnd = 引号对白正则.lastIndex;
         const speech = (match[1] || '').trim();
         const prefix = source.slice(0, quoteStart);
-        let speaker = 推断说话人(prefix, knownSpeakers);
-        let inferredFromSuffix = false;
-        if (!speaker) {
-            speaker = 推断后置信息说话人(source.slice(quoteEnd), knownSpeakers);
-            inferredFromSuffix = Boolean(speaker);
-        }
-        if (!speaker && lastSpeaker && 是否像引号对白内容(speech)) {
-            speaker = lastSpeaker;
-        }
-
-        const hasLeadingCue = 是否像说话引导(prefix, speaker);
-        const hasReliableSpeakerCue = hasLeadingCue || inferredFromSuffix || (!!lastSpeaker && speaker === lastSpeaker);
-        if (!speech || !speaker || (!hasReliableSpeakerCue && !是否像引号对白内容(speech))) continue;
-        if (!inferredFromSuffix && speaker !== lastSpeaker && !hasLeadingCue) continue;
-
-        const before = 移除尾部说话引导(source.slice(cursor, quoteStart), speaker);
+        // Only accept explicit bracketed speaker immediately before the quote.
+        const prefixSegment = source.slice(Math.max(0, quoteStart - 40), quoteStart);
+        const bracketMatch = prefixSegment.match(/【\s*([^】【]{1,16})\s*】\s*$/);
+        if (!speech || !bracketMatch) continue;
+        const speaker = 清理说话人(bracketMatch[1] || '');
+        if (!speaker) continue;
+        const bracketStart = quoteStart - prefixSegment.length + (bracketMatch.index ?? 0);
+        const before = 移除尾部说话引导(source.slice(cursor, bracketStart), speaker);
         if (before.trim()) parts.push({ sender: '旁白', text: before.trim() });
         parts.push({ sender: speaker, text: speech });
         lastSpeaker = speaker;


### PR DESCRIPTION
修复剧情解析中，无标签引号句、旁白或上下文推断内容被错误识别为角色对话框的问题。

变更内容：
- 收紧角色对话识别规则
- 只有明确以【角色名】开头的内容才生成角色对话
- 无标签引号句、旁白、心理活动、惊呼保持为旁白
- 补充相关测试用例

测试：
- 本地运行 npm run build
- 本地页面验证无标签引号句不再生成角色对话框

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进对话格式识别逻辑，更准确地处理带括号和引号的对白文本
  * 优化括号标记和冒号引导的解析规则，减少误拆分为独立角色对白

* **Tests**
  * 新增和更新多个测试用例，覆盖引号、括号等对白识别的边界场景

<!-- end of auto-generated comment: release notes by coderabbit.ai -->