### PR TITLE
fix: 修复左侧状态栏标题区域无法滚动

### DIFF
--- a/components/layout/LeftPanel.tsx
+++ b/components/layout/LeftPanel.tsx
@@ -279,7 +279,7 @@ const LeftPanel: React.FC<Props> = ({ 角色, onOpenCharacter, onOpenVariableMan
     };
 
     return (
-        <div className="left-panel-body h-full flex flex-col p-3 border-r border-gray-900 relative overflow-y-auto overflow-x-hidden no-scrollbar bg-transparent" style={areaStyle}>
+        <div className="left-panel-body h-full min-h-0 flex flex-col p-3 border-r border-gray-900 relative overflow-y-auto overflow-x-hidden no-scrollbar bg-transparent" style={areaStyle}>
             <input
                 ref={avatarInputRef}
                 type="file"
@@ -418,7 +418,7 @@ const LeftPanel: React.FC<Props> = ({ 角色, onOpenCharacter, onOpenVariableMan
                 </div>
             )}
 
-            <div className="shrink-0 pt-2 border-t border-gray-800/50 flex-1 overflow-y-auto no-scrollbar">
+            <div className="shrink-0 pt-2 border-t border-wuxia-gold/25 no-scrollbar">
                 <div className="border border-gray-800 bg-white/5 p-1.5 flex flex-col relative group hover:border-gray-700 transition-colors">
                     <button
                         type="button"


### PR DESCRIPTION
修复左侧角色状态栏中，鼠标放在“身躯 / 行头”等分组标题区域时无法滚动的问题。

原因是“行头”区域自身设置了 `flex-1 overflow-y-auto`，形成了独立滚动容器，导致左侧栏滚动行为依赖鼠标所在区域。

本次修改：
- 保留 LeftPanel 根节点作为统一滚动容器
- 给根节点补充 `min-h-0`
- 移除“行头”区域的 `flex-1 overflow-y-auto`
- 保持现有 UI 基本不变

测试：
- `npm run build`
- 手动验证鼠标放在身躯标题、行头标题、BUFF、钱财、身体/装备条目等区域时，左侧栏均可整体滚动

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整左侧栏布局高度约束，改善在复杂内容下的显示稳定性。
  * 优化“玩家BUFF”下方列表区域的滚动与伸缩表现，减少内容挤压或异常滚动问题。
  * 更新该区域顶部边框样式，视觉上更符合整体主题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->