### PR TITLE
fix: 修复正文含“你”时误判为第二人称

### DIFF
--- a/__tests__/storyLengthValidation.test.ts
+++ b/__tests__/storyLengthValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { 校验主剧情正文最低字数, 获取主剧情正文不足信息, 统计正文字符数 } from '../hooks/useGame/sendWorkflow';
+import { 校验响应人称一致性, 校验主剧情正文最低字数, 获取主剧情正文不足信息, 统计正文字符数 } from '../hooks/useGame/sendWorkflow';
 import { 净化角色对白行, 评估润色长度结果, 检测文章优化协议确认污染, 解析正文日志文本 } from '../hooks/useGame/bodyPolish';
 import { 清理润色正文输出 } from '../services/ai/storyTasks';
 import { 构建主剧情请求参数, type 主剧情系统上下文 } from '../hooks/useGame/mainStoryRequest';
@@ -330,5 +330,73 @@ describe('主剧情正文字数校验', () => {
 
         expect(result.tavernPresetModeEnabled).toBe(true);
         expect(result.orderedMessages.some((message) => message.content.includes('2200字以上'))).toBe(true);
+    });
+});
+
+describe('主剧情叙事人称校验', () => {
+    const rawText = '<正文>测试正文</正文>';
+
+    it('第三人称旁白 + 角色对白含“你”时不报错', () => {
+        expect(() => 校验响应人称一致性({
+            角色: { 姓名: '沈砚' },
+            logs: [
+                { sender: '旁白', text: '林清月垂下眼，袖口的雨水顺着指尖滴落。' },
+                { sender: '林清月', text: '你没有要过她任何一丝一毫的回报。' }
+            ]
+        } as any, rawText, '第三人称')).not.toThrow();
+    });
+
+    it('第三人称旁白引号内含“你”时不报错', () => {
+        expect(() => 校验响应人称一致性({
+            角色: { 姓名: '沈砚' },
+            logs: [
+                { sender: '旁白', text: '林清月低声说：“你走进房间。你感到一阵寒意。”随后她把目光移向窗外。' }
+            ]
+        } as any, rawText, '第三人称')).not.toThrow();
+    });
+
+    it('玩家输入摘要、系统提示和任务提示含“你”时不报错', () => {
+        expect(() => 校验响应人称一致性({
+            角色: { 姓名: '沈砚' },
+            logs: [
+                {
+                    sender: '旁白',
+                    text: [
+                        '玩家输入摘要：你走进房间，询问林清月。',
+                        '系统提示：你感到一阵寒意时需要等待判定。',
+                        '任务提示：你决定继续向前会推进主线。',
+                        '林清月站在廊下，雨声遮住了她短促的呼吸。'
+                    ].join('\n')
+                }
+            ]
+        } as any, rawText, '第三人称')).not.toThrow();
+    });
+
+    it('第三人称正文不出现主角姓名、只用他她少年时不报错', () => {
+        expect(() => 校验响应人称一致性({
+            角色: { 姓名: '沈砚' },
+            logs: [
+                { sender: '旁白', text: '少年推开木门，望见廊下的灯影。他停了片刻，随后向她点头。' }
+            ]
+        } as any, rawText, '第三人称')).not.toThrow();
+    });
+
+    it('正文主体明显连续使用第二人称时会报错', () => {
+        expect(() => 校验响应人称一致性({
+            角色: { 姓名: '沈砚' },
+            logs: [
+                { sender: '旁白', text: '你走进房间。你感到寒意。你决定继续向前。' }
+            ]
+        } as any, rawText, '第三人称')).toThrow(/叙事人称不符/);
+    });
+
+    it('第一人称模式下，对话里出现“你”但旁白稳定用“我”时不报错', () => {
+        expect(() => 校验响应人称一致性({
+            角色: { 姓名: '沈砚' },
+            logs: [
+                { sender: '旁白', text: '我走进房间，听见窗外雨声渐急。我决定先把灯点亮。' },
+                { sender: '林清月', text: '你先别急，外面还有人。' }
+            ]
+        } as any, rawText, '第一人称')).not.toThrow();
     });
 });

--- a/hooks/useGame/sendWorkflow.ts
+++ b/hooks/useGame/sendWorkflow.ts
@@ -220,34 +220,29 @@ export const 校验响应人称一致性 = (
     rawText: string,
     expectedPov: string
 ) => {
-    const bodyText = Array.isArray(response?.logs)
-        ? response.logs.map((log: any) => typeof log?.text === 'string' ? log.text : '').join('')
-        : '';
+    const bodyText = 构建叙事人称检测文本(response);
     if (!bodyText) return;
     const sample = bodyText.slice(0, 2000);
     const playerName = typeof response?.角色?.姓名 === 'string' ? response.角色.姓名.trim() : '';
+    const secondPersonNarrationCount = 统计明显第二人称叙述(sample);
     if (expectedPov === '第二人称') {
-        const hasYou = /你/.test(sample);
-        const hasHeShe = playerName && new RegExp(playerName).test(sample);
-        if (!hasYou && hasHeShe) {
+        const hasHeShe = playerName && new RegExp(转义正则片段(playerName)).test(sample);
+        if (secondPersonNarrationCount <= 0 && hasHeShe) {
             const detail = `叙事人称不符：设置了第二人称但正文使用了第三人称（出现主角姓名"${playerName}"而未出现"你"）。请用第二人称"你"重新生成正文。`;
             const error = new textAIService.StoryResponseParseError(detail, rawText, detail);
             (error as any).parseDetail = detail;
             throw error;
         }
     } else if (expectedPov === '第一人称') {
-        const hasI = /[\u4e00-\u9fff]我/.test(sample) || /^我/.test(sample);
-        const hasYou = /你/.test(sample);
-        if (!hasI && hasYou) {
+        const hasI = 统计明显第一人称叙述(sample) > 0;
+        if (!hasI && secondPersonNarrationCount >= 2) {
             const detail = '叙事人称不符：设置了第一人称但正文使用了第二人称。请用第一人称"我"重新生成正文。';
             const error = new textAIService.StoryResponseParseError(detail, rawText, detail);
             (error as any).parseDetail = detail;
             throw error;
         }
     } else if (expectedPov === '第三人称') {
-        const hasHeShe = playerName && new RegExp(playerName).test(sample);
-        const hasYou = /你/.test(sample);
-        if (!hasHeShe && hasYou) {
+        if (secondPersonNarrationCount >= 2) {
             const detail = `叙事人称不符：设置了第三人称但正文使用了第二人称。请用第三人称"${playerName || '他/她'}"重新生成正文。`;
             const error = new textAIService.StoryResponseParseError(detail, rawText, detail);
             (error as any).parseDetail = detail;
@@ -255,6 +250,50 @@ export const 校验响应人称一致性 = (
         }
     }
 };
+
+const 叙事人称元信息行正则 = /(?:玩家输入|玩家指令|当前指令|系统提示|任务提示|行动选项|选项|提示|总结|Step|已知事实|协议命中|当前地点|当前时间)/i;
+const 第二人称叙述动作正则 = /你\s*(?:走|来到|进入|推开|看见|望向|抬手|伸手|感到|觉得|意识到|决定|继续|停下|听见|发现|坐下|站起|转身|拿起|打开|闭上|回头|靠近|离开)/g;
+const 第一人称叙述动作正则 = /我\s*(?:走|来到|进入|推开|看见|望向|抬手|伸手|感到|觉得|意识到|决定|继续|停下|听见|发现|坐下|站起|转身|拿起|打开|闭上|回头|靠近|离开)/g;
+
+const 转义正则片段 = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const 移除引号内文本 = (value: string): string => {
+    let text = value || '';
+    const quoteRules = [
+        /“[^”]*”/g,
+        /「[^」]*」/g,
+        /『[^』]*』/g,
+        /"[^"]*"/g,
+        /'[^']*'/g
+    ];
+    for (const rule of quoteRules) {
+        text = text.replace(rule, '');
+    }
+    return text;
+};
+
+const 净化叙事人称检测文本 = (value: string): string => 移除引号内文本(value)
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .filter(line => !叙事人称元信息行正则.test(line))
+    .join('\n');
+
+const 构建叙事人称检测文本 = (response: GameResponse): string => {
+    if (!Array.isArray(response?.logs)) return '';
+    return response.logs
+        .filter((log: any) => {
+            const sender = typeof log?.sender === 'string' ? log.sender.trim() : '';
+            return !sender || sender === '旁白';
+        })
+        .map((log: any) => typeof log?.text === 'string' ? 净化叙事人称检测文本(log.text) : '')
+        .filter(Boolean)
+        .join('\n');
+};
+
+const 统计明显第二人称叙述 = (value: string): number => (value.match(第二人称叙述动作正则) || []).length;
+const 统计明显第一人称叙述 = (value: string): number => (value.match(第一人称叙述动作正则) || []).length;
 
 const 规范化姓名键 = (value: unknown): string => (
     typeof value === 'string'
@@ -2551,6 +2590,13 @@ export const 执行主剧情发送工作流 = async (
             }
             const parseFailureGameConfig = 规范化游戏设置(currentState.gameConfig);
             const parseFailureApi = 获取主剧情接口配置(currentState.apiConfig);
+            const parseErrorTitle = /叙事人称不符/.test([
+                parseErrorRaw,
+                error?.parseDetail,
+                error?.message
+            ].filter(Boolean).join('\n'))
+                ? '叙事人称不符'
+                : '标签结构不完整';
             recordAiParseFailureDiagnostic({
                 stage: 'main_story',
                 error,
@@ -2583,7 +2629,7 @@ export const 执行主剧情发送工作流 = async (
                     parseErrorMessage: parseErrorRaw,
                     parseErrorDetail: parseErrorRaw,
                     parseErrorRawText,
-                    errorTitle: '标签结构不完整',
+                    errorTitle: parseErrorTitle,
                     recoveryHint: '可直接手动补全缺失标签后恢复，或尝试自动修复恢复；如果不想保留这版内容，也可以直接重ROLL。'
                 };
             }
@@ -2595,7 +2641,7 @@ export const 执行主剧情发送工作流 = async (
                     ? `${parseErrorRaw}\n\n当前已关闭“标签协议失败自动回炉”。最佳选择是直接重ROLL；若想保留这版内容，可点“查看/编辑原文”后修复缺失标签再重解析。`
                     : parseErrorRaw,
                 parseErrorRawText,
-                errorTitle: '标签结构不完整',
+                errorTitle: parseErrorTitle,
                 recoveryHint: '可直接手动补全缺失标签后恢复，或尝试自动修复恢复；如果不想保留这版内容，也可以直接重ROLL。'
             };
         }


### PR DESCRIPTION
修复第三人称剧情中，正文或对白里出现“你”时被误判为第二人称叙述的问题。

问题原因

原先的人称一致性检测会在第三人称模式下直接扫描正文样本中的 你，并结合主角名是否出现来判断是否存在第二人称叙述。

这会导致正常内容被误判，例如：

* 角色对白里出现“你”
* 引号内引用出现“你”
* 玩家输入摘要 / 系统提示 / 任务提示中出现“你”
* 第三人称正文没有直接写主角姓名，只用“他 / 她 / 少年”等称呼

同时，人称错误此前会被 UI 归类为“标签结构不完整”，提示标题不够准确。

修改内容

* 人称检测优先只分析旁白或无 sender 的正文日志
* 检测前移除中文 / 英文引号内文本
* 过滤玩家输入、系统提示、任务提示、行动选项、总结、Step、当前地点、当前时间等元信息行
* 不再因为孤立出现 你 就判定第二人称
* 改为检测明显第二人称叙述模式，并要求至少命中 2 次才报错
* 第三人称模式不再要求正文必须出现主角姓名
* 人称错误的 UI 标题改为“叙事人称不符”，其它解析错误仍显示“标签结构不完整”

测试

* npm run test:run -- __tests__/storyLengthValidation.test.ts
* npm run build
* 本地网页手动验证原误报场景不再弹错