### PR TITLE
fix: 优化动态世界与规划分析流式反馈

### DIFF
--- a/__tests__/planningUpdateWorkflow.test.ts
+++ b/__tests__/planningUpdateWorkflow.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/ai/text', () => ({
+    generatePlanningAnalysis: vi.fn(async (_params, _api, _signal, streamOptions) => {
+        streamOptions?.onDelta?.('增量', '累计文本');
+        return {
+            shouldUpdate: false,
+            reason: '无需更新',
+            rawText: '累计文本',
+            commands: []
+        };
+    })
+}));
+
+vi.mock('../utils/apiConfig', () => ({
+    获取规划分析接口配置: vi.fn(() => ({ baseUrl: 'https://example.com', apiKey: 'test', model: 'test-model' })),
+    接口配置是否可用: vi.fn(() => true)
+}));
+
+vi.mock('../utils/backgroundScheduling', () => ({
+    后台分段执行: vi.fn(async (fn) => fn()),
+    后台让出主线程: vi.fn(async () => undefined)
+}));
+
+vi.mock('../utils/gameHeavyWorkerClient', () => ({
+    执行游戏后台重计算: vi.fn(async (_task, _payload, fallback) => fallback())
+}));
+
+vi.mock('../services/novelDecompositionInjection', () => ({
+    获取激活小说拆分注入文本: vi.fn(async () => '')
+}));
+
+vi.mock('../services/novelDecompositionCalibration', () => ({
+    同步剧情小说分解时间校准: vi.fn(async ({ nextStory }) => nextStory)
+}));
+
+import { 创建规划更新工作流 } from '../hooks/useGame/planningUpdateWorkflow';
+
+const 创建基础依赖 = () => ({
+    apiConfig: {},
+    gameConfig: {},
+    角色: { 姓名: '张三' },
+    环境: {},
+    世界: {},
+    战斗: {},
+    玩家门派: {},
+    任务列表: [],
+    约定列表: [],
+    历史记录: [],
+    规划分析进行中Ref: { current: false },
+    prompts: [],
+    worldbooks: [],
+    规范化环境信息: (envLike?: any) => envLike || {},
+    规范化社交列表: (raw?: any[]) => Array.isArray(raw) ? raw : [],
+    规范化世界状态: (raw?: any) => raw || {},
+    规范化战斗状态: (raw?: any) => raw || {},
+    规范化门派状态: (raw?: any) => raw || {},
+    规范化剧情状态: (raw?: any) => raw || {},
+    规范化剧情规划状态: (raw?: any) => raw || {},
+    规范化女主剧情规划状态: (raw?: any) => raw,
+    规范化同人剧情规划状态: (raw?: any) => raw,
+    规范化同人女主剧情规划状态: (raw?: any) => raw,
+    深拷贝: <T,>(value: T): T => JSON.parse(JSON.stringify(value)),
+    收集最近完整正文回合: () => [{ role: 'assistant', content: '正文' }],
+    构建最近完整正文上下文: () => '正文',
+    去重文本数组: (items: string[]) => [...new Set(items)],
+    收集女主规划时间触发原因: () => [],
+    收集女主正文命中原因: () => [],
+    收集剧情规划时间触发原因: () => [],
+    收集剧情正文命中原因: () => [],
+    提取响应完整正文文本: () => '正文',
+    设置剧情: vi.fn(),
+    设置剧情规划: vi.fn(),
+    设置女主剧情规划: vi.fn(),
+    设置同人剧情规划: vi.fn(),
+    设置同人女主剧情规划: vi.fn(),
+    performAutoSave: vi.fn(async () => undefined)
+});
+
+describe('规划更新工作流', () => {
+    it('隔离 onStreamDelta 消费端异常，避免打断规划分析流程', async () => {
+        const workflow = 创建规划更新工作流(创建基础依赖());
+
+        await expect(workflow.后台执行统一规划分析({
+            state: {
+                环境: {},
+                社交: [],
+                世界: {},
+                剧情: {},
+                剧情规划: {}
+            },
+            playerInput: '继续',
+            gameTime: '辰时',
+            response: { logs: [] } as any,
+            onStreamDelta: () => {
+                throw new Error('UI 更新失败');
+            }
+        })).resolves.toMatchObject({
+            updated: false,
+            message: '无需更新',
+            rawText: '累计文本'
+        });
+    });
+});

--- a/__tests__/publishReleaseGithubScript.test.ts
+++ b/__tests__/publishReleaseGithubScript.test.ts
@@ -7,9 +7,10 @@ const scriptPath = path.join(process.cwd(), 'scripts', 'publish-release-github.m
 describe('GitHub release publish script', () => {
     it('uploads the versioned APK asset when creating a new release', () => {
         const source = readFileSync(scriptPath, 'utf8');
-        const createCommand = source.match(/spawnSync\('gh', \[\s*'release', 'create'[\s\S]*?\], \{ encoding: 'utf8', timeout: 600000 \}\);/)?.[0] || '';
+        const createCommandMatch = source.match(/spawnSync\('gh', \[\s*'release', 'create'[\s\S]*?\], \{ encoding: 'utf8', timeout: 600000 \}\);/);
+        const createCommand = createCommandMatch?.[0] || '';
 
-        expect(createCommand).not.toBe('');
+        expect(createCommand, '未找到 gh release create 命令块，请检查 publish-release-github.mjs 的创建发布逻辑').not.toBe('');
         expect(createCommand).toContain('uploadApkPath');
         expect(createCommand).not.toContain('apkPath,');
     });

--- a/__tests__/publishReleaseGithubScript.test.ts
+++ b/__tests__/publishReleaseGithubScript.test.ts
@@ -7,12 +7,9 @@ const scriptPath = path.join(process.cwd(), 'scripts', 'publish-release-github.m
 describe('GitHub release publish script', () => {
     it('uploads the versioned APK asset when creating a new release', () => {
         const source = readFileSync(scriptPath, 'utf8');
-        const createStart = source.indexOf("spawnSync('gh', [\n    'release', 'create'");
-        const createEnd = source.indexOf("], { encoding: 'utf8', timeout: 600000 });", createStart);
-        const createCommand = source.slice(createStart, createEnd);
+        const createCommand = source.match(/spawnSync\('gh', \[\s*'release', 'create'[\s\S]*?\], \{ encoding: 'utf8', timeout: 600000 \}\);/)?.[0] || '';
 
-        expect(createStart).toBeGreaterThanOrEqual(0);
-        expect(createEnd).toBeGreaterThan(createStart);
+        expect(createCommand).not.toBe('');
         expect(createCommand).toContain('uploadApkPath');
         expect(createCommand).not.toContain('apkPath,');
     });

--- a/components/features/Chat/InputArea.tsx
+++ b/components/features/Chat/InputArea.tsx
@@ -42,7 +42,7 @@ type PolishProgress = {
 };
 
 type WorldEvolutionProgress = {
-    phase: 'start' | 'done' | 'error' | 'skipped' | 'cancelled';
+    phase: 'start' | 'stream' | 'done' | 'error' | 'skipped' | 'cancelled';
     text?: string;
     rawText?: string;
     commandTexts?: string[];
@@ -54,7 +54,7 @@ type WorldEvolutionProgress = {
 };
 
 type PlanningProgress = {
-    phase: 'start' | 'done' | 'error' | 'skipped' | 'cancelled';
+    phase: 'start' | 'stream' | 'done' | 'error' | 'skipped' | 'cancelled';
     text?: string;
     rawText?: string;
     commandTexts?: string[];
@@ -130,6 +130,8 @@ const 格式化队列耗时 = (elapsedMs?: number): string => {
 const 队列阶段不调用AI = (progress?: QueueProgressPayload | null): boolean => (
     String(progress?.modelName || '').trim().toLowerCase() === '不调用 ai'
 );
+
+const 队列阶段运行中 = (phase?: string): boolean => phase === 'start' || phase === 'stream';
 
 type IndependentStageId = 'polish' | 'world' | 'planning' | 'variable' | 'map';
 type IndependentStageFailureDecision = 'retry' | 'skip';
@@ -708,7 +710,7 @@ const InputArea: React.FC<Props> = ({
     const openingQueueHasError = openingProgressItems
         .some((item) => item?.phase === 'error');
     const openingQueueRunning = openingProgressItems
-        .some((item) => item?.phase === 'start');
+        .some((item) => 队列阶段运行中(item?.phase));
     const openingFinalProgress = openingQueueHasError
         ? null
         : (openingQueueRunning
@@ -738,8 +740,8 @@ const InputArea: React.FC<Props> = ({
         { id: 'map', label: '地图更新', progress: effectiveMapUpdateProgress }
     ]);
     const queueVisible = pipelineStages.some((stage) => Boolean(stage.progress));
-    const currentRunningStage = pipelineStages.find((stage) => stage.progress?.phase === 'start');
-    const latestFinishedStage = [...pipelineStages].reverse().find((stage) => stage.progress && stage.progress.phase !== 'start');
+    const currentRunningStage = pipelineStages.find((stage) => 队列阶段运行中(stage.progress?.phase));
+    const latestFinishedStage = [...pipelineStages].reverse().find((stage) => stage.progress && !队列阶段运行中(stage.progress.phase));
     const queueRunning = Boolean(currentRunningStage);
     const queueBadgeClass = queueRunning
         ? 'border-wuxia-cyan/60 bg-gradient-to-r from-wuxia-cyan/20 via-wuxia-gold/15 to-wuxia-cyan/20 text-wuxia-cyan animate-pulse shadow-[0_0_18px_rgba(34,211,238,0.2)]'
@@ -753,7 +755,7 @@ const InputArea: React.FC<Props> = ({
     );
     const 取阶段状态文案 = (phase?: string): string => {
         if (!phase) return '待命';
-        if (phase === 'start') return '处理中';
+        if (phase === 'start' || phase === 'stream') return '处理中';
         if (phase === 'done') return '完成';
         if (phase === 'error') return '失败';
         if (phase === 'skipped') return '已跳过';
@@ -764,7 +766,7 @@ const InputArea: React.FC<Props> = ({
         if (phase === 'done') return 'text-green-400';
         if (phase === 'error') return 'text-red-400';
         if (phase === 'skipped' || phase === 'cancelled') return 'text-gray-400';
-        if (phase === 'start') return 'text-wuxia-cyan';
+        if (phase === 'start' || phase === 'stream') return 'text-wuxia-cyan';
         return 'text-gray-500';
     };
 
@@ -776,7 +778,7 @@ const InputArea: React.FC<Props> = ({
             effectiveWorldEvolutionProgress,
             effectivePlanningProgress,
             effectiveMapUpdateProgress
-        ].some((item) => item?.phase === 'start' || item?.phase === 'done' || item?.phase === 'error' || item?.phase === 'skipped' || item?.phase === 'cancelled');
+        ].some((item) => 队列阶段运行中(item?.phase) || item?.phase === 'done' || item?.phase === 'error' || item?.phase === 'skipped' || item?.phase === 'cancelled');
         const hasRunningQueueStage = [
             polishProgress,
             openingPolishProgress,
@@ -784,7 +786,7 @@ const InputArea: React.FC<Props> = ({
             effectiveWorldEvolutionProgress,
             effectivePlanningProgress,
             effectiveMapUpdateProgress
-        ].some((item) => item?.phase === 'start');
+        ].some((item) => 队列阶段运行中(item?.phase));
         if (hasQueueProgress && (hasRunningQueueStage || postStoryQueueRunning)) {
             // 不再自动展开面板，保持收缩状态让用户手动点开
         }
@@ -902,12 +904,14 @@ const InputArea: React.FC<Props> = ({
                                 </div>
                                 <div className="grid grid-cols-1 gap-2">
                                     {pipelineStages.map((stage, index) => {
-                                        const phase = stage.progress?.phase;
-                                        const fullRawText = stage.progress?.rawText || '';
+                                        const progress = stage.progress;
+                                        const phase = progress?.phase;
+                                        const isRunningStage = Boolean(phase && 队列阶段运行中(phase));
+                                        const fullRawText = progress?.rawText || '';
                                         const rawText = fullRawText;
-                                        const progressText = stage.progress?.text;
-                                        const originalCommandTexts = Array.isArray((stage.progress as { commandTexts?: string[] } | null)?.commandTexts)
-                                            ? ((stage.progress as { commandTexts?: string[] }).commandTexts || [])
+                                        const progressText = progress?.text;
+                                        const originalCommandTexts = Array.isArray((progress as { commandTexts?: string[] } | null)?.commandTexts)
+                                            ? ((progress as { commandTexts?: string[] }).commandTexts || [])
                                             : [];
                                         const commandTexts = originalCommandTexts;
                                         const commandDisplayText = 合并队列命令展示(commandTexts);
@@ -916,7 +920,12 @@ const InputArea: React.FC<Props> = ({
                                         const isVariableStage = stage.id === 'variable';
                                         const hidesModel = 队列阶段不调用AI(stage.progress);
                                         const elapsedText = 格式化队列耗时(stage.progress?.elapsedMs);
-                                        const rerunAction = phase !== 'start' && !variableGenerationRunning
+                                        const hasVisibleProgressText = Boolean(
+                                            typeof progressText === 'string'
+                                            && progressText.trim().length > 0
+                                            && isRunningStage
+                                        );
+                                        const rerunAction = !isRunningStage && !variableGenerationRunning
                                             ? 获取队列阶段重新生成动作({
                                                 stageId: stage.id,
                                                 isOpeningQueue,
@@ -930,7 +939,7 @@ const InputArea: React.FC<Props> = ({
                                                 <div className="flex items-center justify-between gap-3">
                                                     <div className="flex items-center gap-2 min-w-0">
                                                         <span className="text-gray-500 text-xs">{index + 1}.</span>
-                                                        {phase === 'start' ? (
+                                                        {isRunningStage ? (
                                                             <RunningSpinner small />
                                                         ) : (
                                                             <span className={取阶段状态色(phase)}>●</span>
@@ -954,7 +963,7 @@ const InputArea: React.FC<Props> = ({
                                                         })()}
                                                     </div>
                                                     <div className="flex items-center gap-2">
-                                                        {isVariableStage && phase === 'start' && variableGenerationRunning && onCancelVariableGeneration && (
+                                                        {isVariableStage && isRunningStage && variableGenerationRunning && onCancelVariableGeneration && (
                                                             <button
                                                                 type="button"
                                                                 onClick={onCancelVariableGeneration}
@@ -1015,7 +1024,7 @@ const InputArea: React.FC<Props> = ({
                                                         )}
                                                     </div>
                                                 </div>
-                                                {progressText && phase === 'start' && (
+                                                {hasVisibleProgressText && (
                                                     <pre className="mt-2 text-sm whitespace-pre-wrap text-gray-300 leading-relaxed max-h-24 sm:max-h-32 overflow-y-auto no-scrollbar">
                                                         {progressText}
                                                     </pre>

--- a/components/features/Chat/InputArea.tsx
+++ b/components/features/Chat/InputArea.tsx
@@ -771,36 +771,6 @@ const InputArea: React.FC<Props> = ({
     };
 
     useEffect(() => {
-        const hasQueueProgress = [
-            polishProgress,
-            openingPolishProgress,
-            effectiveVariableGenerationProgress,
-            effectiveWorldEvolutionProgress,
-            effectivePlanningProgress,
-            effectiveMapUpdateProgress
-        ].some((item) => 队列阶段运行中(item?.phase) || item?.phase === 'done' || item?.phase === 'error' || item?.phase === 'skipped' || item?.phase === 'cancelled');
-        const hasRunningQueueStage = [
-            polishProgress,
-            openingPolishProgress,
-            effectiveVariableGenerationProgress,
-            effectiveWorldEvolutionProgress,
-            effectivePlanningProgress,
-            effectiveMapUpdateProgress
-        ].some((item) => 队列阶段运行中(item?.phase));
-        if (hasQueueProgress && (hasRunningQueueStage || postStoryQueueRunning)) {
-            // 不再自动展开面板，保持收缩状态让用户手动点开
-        }
-    }, [
-        postStoryQueueRunning,
-        polishProgress?.phase,
-        openingPolishProgress?.phase,
-        effectiveVariableGenerationProgress?.phase,
-        effectiveWorldEvolutionProgress?.phase,
-        effectivePlanningProgress?.phase,
-        effectiveMapUpdateProgress?.phase
-    ]);
-
-    useEffect(() => {
         const hasMainQueueError = [
             polishProgress,
             openingPolishProgress,
@@ -907,8 +877,7 @@ const InputArea: React.FC<Props> = ({
                                         const progress = stage.progress;
                                         const phase = progress?.phase;
                                         const isRunningStage = Boolean(phase && 队列阶段运行中(phase));
-                                        const fullRawText = progress?.rawText || '';
-                                        const rawText = fullRawText;
+                                        const rawText = progress?.rawText || '';
                                         const progressText = progress?.text;
                                         const originalCommandTexts = Array.isArray((progress as { commandTexts?: string[] } | null)?.commandTexts)
                                             ? ((progress as { commandTexts?: string[] }).commandTexts || [])
@@ -1004,7 +973,7 @@ const InputArea: React.FC<Props> = ({
                                                         {rawText && (
                                                             <button
                                                                 type="button"
-                                                                onClick={() => { void 复制队列文本(fullRawText, `${stage.label}原始回复`); }}
+                                                                onClick={() => { void 复制队列文本(rawText, `${stage.label}原始回复`); }}
                                                                 className="text-xs px-2 py-1 border border-emerald-700/70 text-emerald-200 rounded hover:border-emerald-400/70 hover:text-white"
                                                             >
                                                                 复制原始回复

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -267,7 +267,7 @@ type 最近开局配置结构 = {
 type 快速重开模式 = 'world_only' | 'opening_only' | 'all';
 
 type 开局独立阶段进度 = {
-    phase: 'start' | 'done' | 'error' | 'skipped' | 'cancelled';
+    phase: 'start' | 'stream' | 'done' | 'error' | 'skipped' | 'cancelled';
     text?: string;
     rawText?: string;
     commandTexts?: string[];
@@ -357,7 +357,7 @@ type 独立阶段失败决策参数 = {
 };
 
 type 规划分析进度 = {
-    phase: 'start' | 'done' | 'error' | 'skipped' | 'cancelled';
+    phase: 'start' | 'stream' | 'done' | 'error' | 'skipped' | 'cancelled';
     text?: string;
     rawText?: string;
     commandTexts?: string[];
@@ -369,7 +369,7 @@ type 规划分析进度 = {
 };
 
 type 世界演变进度 = {
-    phase: 'start' | 'done' | 'error' | 'skipped' | 'cancelled';
+    phase: 'start' | 'stream' | 'done' | 'error' | 'skipped' | 'cancelled';
     text?: string;
     rawText?: string;
     commandTexts?: string[];

--- a/hooks/useGame/planningUpdateWorkflow.ts
+++ b/hooks/useGame/planningUpdateWorkflow.ts
@@ -315,6 +315,7 @@ export const 创建规划更新工作流 = (deps: 规划更新工作流依赖) =
         response: GameResponse;
         shouldApply?: () => boolean;
         onRetry?: (attempt: number, maxAttempts: number, reason: string) => void;
+        onStreamDelta?: (delta: string, accumulated: string) => void;
         signal?: AbortSignal;
     }): Promise<统一规划分析结果> => {
         检查规划分析中断(params.signal);
@@ -564,7 +565,10 @@ export const 创建规划更新工作流 = (deps: 规划更新工作流依赖) =
             gptMode: 独立规划分析GPT模式
         }, planningApi, signal, 规划分析非流式输出 ? undefined : {
             stream: true,
-            onDelta: markStreamActivity
+            onDelta: (delta, accumulated) => {
+                markStreamActivity();
+                params.onStreamDelta?.(delta, accumulated);
+            }
         }), params.onRetry, params.signal), {
             firstResponseTimeoutMs: 规划分析首次响应超时毫秒,
             streamIdleTimeoutMs: 规划分析流式空闲超时毫秒,

--- a/hooks/useGame/planningUpdateWorkflow.ts
+++ b/hooks/useGame/planningUpdateWorkflow.ts
@@ -567,7 +567,11 @@ export const 创建规划更新工作流 = (deps: 规划更新工作流依赖) =
             stream: true,
             onDelta: (delta, accumulated) => {
                 markStreamActivity();
-                params.onStreamDelta?.(delta, accumulated);
+                try {
+                    params.onStreamDelta?.(delta, accumulated);
+                } catch (err) {
+                    console.error('[规划分析] onStreamDelta 回调异常', err);
+                }
             }
         }), params.onRetry, params.signal), {
             firstResponseTimeoutMs: 规划分析首次响应超时毫秒,

--- a/hooks/useGame/sendWorkflow.ts
+++ b/hooks/useGame/sendWorkflow.ts
@@ -2,7 +2,7 @@ import * as textAIService from '../../services/ai/text';
 import { recordAiParseFailureDiagnostic } from '../../services/diagnosticContext';
 import { recordDiagnosticLog } from '../../services/diagnosticLog';
 import type { GameResponse, OpeningConfig, 聊天记录结构, 记忆系统结构, 角色数据结构, 剧情系统结构, 剧情规划结构, 女主剧情规划结构, 同人剧情规划结构, 同人女主剧情规划结构, 世界书结构, 内置提示词条目结构 } from '../../types';
-import { 获取主剧情接口配置, 获取剧情回忆接口配置, 获取文章优化接口配置, 获取变量计算接口配置, 获取世界演变接口配置, 获取规划分析接口配置, 获取地图自动更新接口配置, 接口配置是否可用 } from '../../utils/apiConfig';
+import { 获取主剧情接口配置, 获取剧情回忆接口配置, 获取文章优化接口配置, 获取变量计算接口配置, 获取世界演变接口配置, 获取规划分析接口配置, 获取地图自动更新接口配置, 接口配置是否可用, 变量校准功能已启用 as 变量生成功能已启用 } from '../../utils/apiConfig';
 import { 规范化游戏设置 } from '../../utils/gameSettings';
 import { 计算正文字数容错字数, 正文字数差距在容错内 } from '../../utils/bodyLengthTolerance';
 import { 构建世界书注入文本 } from '../../utils/worldbook';
@@ -82,7 +82,7 @@ type 独立阶段失败决策参数 = {
 };
 
 type 规划分析进度 = {
-    phase: 'start' | 'done' | 'error' | 'skipped' | 'cancelled';
+    phase: 'start' | 'stream' | 'done' | 'error' | 'skipped' | 'cancelled';
     text?: string;
     rawText?: string;
     commandTexts?: string[];
@@ -943,6 +943,7 @@ type 主剧情发送依赖 = {
         response: GameResponse;
         shouldApply?: () => boolean;
         onRetry?: (attempt: number, maxAttempts: number, reason: string) => void;
+        onStreamDelta?: (delta: string, accumulated: string) => void;
         signal?: AbortSignal;
     }) => Promise<{ updated: boolean; message: string; rawText?: string; commands: any[]; storyPlanCommands?: any[]; heroinePlanCommands?: any[] }>;
     后台执行变量生成: (params: {
@@ -1958,7 +1959,8 @@ export const 执行主剧情发送工作流 = async (
             try {
                 const 文章优化开启 = deps.文章优化功能已开启();
                 const 变量生成配置 = 获取变量计算接口配置(currentState.apiConfig);
-                const 变量生成开启 = 接口配置是否可用(变量生成配置);
+                const 变量生成总开关开启 = 变量生成功能已启用(currentState.apiConfig);
+                const 变量生成开启 = 变量生成总开关开启 && 接口配置是否可用(变量生成配置);
                 const 文章优化配置 = 获取文章优化接口配置(currentState.apiConfig);
                 const 文章优化变量可并行 = 文章优化开启
                     && 变量生成开启
@@ -2109,19 +2111,30 @@ export const 执行主剧情发送工作流 = async (
                         || "变量生成失败"
                     )
                 });
-                let variableStage: Awaited<ReturnType<typeof 执行变量生成阶段>>;
-                if (文章优化变量可并行) {
-                    const baseDisplayResponse = finalDisplayResponse;
-                    const [polishStage, parallelVariableStage] = await Promise.all([
-                        执行文章优化阶段(),
-                        执行变量生成阶段(baseDisplayResponse)
-                    ]);
-                    应用文章优化结果(polishStage);
-                    variableStage = parallelVariableStage;
-                } else {
+                let variableStage: Awaited<ReturnType<typeof 执行变量生成阶段>> | null = null;
+                if (!变量生成开启) {
+                    options?.onVariableGenerationProgress?.({
+                        phase: "skipped",
+                        text: 变量生成总开关开启
+                            ? "变量生成接口未配置，已跳过。"
+                            : "变量生成功能已关闭，已跳过。"
+                    });
                     const polishStage = await 执行文章优化阶段();
                     应用文章优化结果(polishStage);
-                    variableStage = await 执行变量生成阶段(finalDisplayResponse);
+                } else {
+                    if (文章优化变量可并行) {
+                        const baseDisplayResponse = finalDisplayResponse;
+                        const [polishStage, parallelVariableStage] = await Promise.all([
+                            执行文章优化阶段(),
+                            执行变量生成阶段(baseDisplayResponse)
+                        ]);
+                        应用文章优化结果(polishStage);
+                        variableStage = parallelVariableStage;
+                    } else {
+                        const polishStage = await 执行文章优化阶段();
+                        应用文章优化结果(polishStage);
+                        variableStage = await 执行变量生成阶段(finalDisplayResponse);
+                    }
                 }
                 variableGenerationResult = variableStage?.result ?? null;
                 if (variableStage?.completed && variableGenerationResult?.mergedParsed) {
@@ -2305,6 +2318,14 @@ export const 执行主剧情发送工作流 = async (
                                     text: `规划分析请求失败，正在自动重试（${attempt}/${maxAttempts}）${reason ? `：${reason}` : ""}`
                                 });
                             },
+                            onStreamDelta: options?.onPlanningProgress
+                                ? (_delta, accumulated) => {
+                                    options?.onPlanningProgress?.({
+                                        phase: "stream",
+                                        text: accumulated
+                                    });
+                                }
+                                : undefined,
                             signal: controller.signal
                         }),
                         onError: (errorText) => {


### PR DESCRIPTION
优化独立更新阶段队列中“动态世界”和“规划分析”的流式反馈显示，并修复变量生成关闭后仍显示运行中的问题。

问题原因

变量生成阶段可以在独立更新阶段队列中实时显示模型输出，但动态世界和规划分析的流式反馈不完整：

* 动态世界底层已经会上报 phase: "stream"，但前端队列没有把 stream 当作运行中状态处理，导致执行中反馈不明显。
* 规划分析底层支持流式输出，但 workflow 只用流式 delta 刷新超时计时，没有把 accumulated 文本继续上报给 UI。
* 变量生成关闭后，部分情况下 UI 仍可能保留变量生成运行态，导致页面显示“变量生成运行中”。

修改内容

* InputArea 支持 phase: "stream" 状态
* 将 start 和 stream 都视为阶段运行中
* 动态世界 / 规划分析在流式输出时会显示运行状态、spinner 和实时文本
* latestFinishedStage 不再把 stream 阶段当成已完成阶段
* 规划分析 workflow 增加 onStreamDelta 透传，将 accumulated 文本上报给队列 UI
* 修复变量生成关闭后仍显示“变量生成运行中”的 UI 残留问题
* 阶段完成后的原始回复、复制原始回复、查看命令等按钮逻辑保持不变

未修改内容

本 PR 不改变：

* 世界演变触发条件
* 世界演变命令规范化和应用逻辑
* 规划分析命令过滤目标
* 规划分析补丁应用逻辑
* 自动重试逻辑
* 变量生成业务逻辑
* AI 提示词
* 存档结构
* 队列顺序

测试

* npm run build

手动验收

* 开启动态世界和规划分析，并使用支持流式输出的模型配置
* 发送一轮正文，展开“独立更新阶段队列”
* 确认动态世界执行中显示 spinner，并实时显示模型返回文本
* 确认规划分析执行中显示 spinner，并实时显示模型返回文本
* 确认阶段完成后仍可查看原始回复、复制原始回复、查看命令
* 关闭变量生成后，再发送一轮，确认不会显示“变量生成运行中”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 进度展示新增“流式进行中”状态，规划分析与世界演变等阶段可在流式输出期间实时更新。
  * 队列面板的运行阶段状态、图标与文案按“流式进行中”同步优化。
* **Bug 修复**
  * 阶段判断与按钮可用时机（重跑/取消/复制等）基于“是否正在运行”重新校准，避免误判为已结束。
  * 规划分析流式增量回传异常不再影响流程完成。
* **测试**
  * 新增覆盖流式增量回调异常容错的单测。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->