### PR TITLE
fix: 让动态世界与规划分析读取玩家本轮指令

### DIFF
--- a/__tests__/historyTurnVariableRetry.test.ts
+++ b/__tests__/historyTurnVariableRetry.test.ts
@@ -127,6 +127,7 @@ describe('history turn variable retry', () => {
         const workflow = 创建历史回合工作流(createBaseDeps({
             执行世界演变更新: async (params: any) => {
                 expect(params.applyCommands).toBe(true);
+                expect(params.playerInput).toBe('继续探索');
                 expect(params.currentResponse.body).toBe('正文仍应保留');
                 params.onStreamDelta?.('世界', '世界演变流式内容');
                 return {

--- a/__tests__/planningPrompts.test.ts
+++ b/__tests__/planningPrompts.test.ts
@@ -59,6 +59,43 @@ describe('planning prompts', () => {
         expect(userPrompt).not.toContain('【当前女主规划树】');
     });
 
+    it('injects current player input as intent constraints without treating it as facts', () => {
+        const userPrompt = 构建统一规划分析用户提示词({
+            playerInput: '本轮暂缓主线，只观察，不要安排刺客袭击。',
+            currentStoryJson: '{}',
+            currentHeroinePlanJson: '{}',
+            worldJson: '{}',
+            socialJson: '[]',
+            envJson: '{}',
+            recentBodiesText: '旁白：主角坐在窗边观察雨夜。',
+            auditFocusText: '常规回合固定审计',
+            heroineEnabled: false
+        });
+
+        expect(userPrompt).toContain('【本轮玩家原始指令】');
+        expect(userPrompt).toContain('本轮暂缓主线，只观察，不要安排刺客袭击。');
+        expect(userPrompt).toContain('不代表已经发生');
+        expect(userPrompt).toContain('不得违背玩家明确提出的“不要、暂缓、禁止、只观察”等限制');
+        expect(userPrompt).toContain('不应因为玩家表达想法，就直接把它安排为已完成或已触发事件');
+    });
+
+    it('omits current player input block when player input is empty', () => {
+        const userPrompt = 构建统一规划分析用户提示词({
+            playerInput: '   ',
+            currentStoryJson: '{}',
+            currentHeroinePlanJson: '{}',
+            worldJson: '{}',
+            socialJson: '[]',
+            envJson: '{}',
+            recentBodiesText: '旁白：主角坐在窗边观察雨夜。',
+            auditFocusText: '常规回合固定审计',
+            heroineEnabled: false
+        });
+
+        expect(userPrompt).not.toContain('【本轮玩家原始指令】');
+        expect(userPrompt).not.toContain('【玩家原始指令使用说明】');
+    });
+
     it('requires opening planning initialization to preserve gender ratio constraints', () => {
         const auditFocus = 构建开局规划初始化审计重点({ heroineEnabled: true });
 

--- a/__tests__/planningUpdateWorkflow.test.ts
+++ b/__tests__/planningUpdateWorkflow.test.ts
@@ -35,6 +35,7 @@ vi.mock('../services/novelDecompositionCalibration', () => ({
 }));
 
 import { 创建规划更新工作流 } from '../hooks/useGame/planningUpdateWorkflow';
+import * as textAIService from '../services/ai/text';
 
 const 创建基础依赖 = () => ({
     apiConfig: {},
@@ -80,6 +81,7 @@ const 创建基础依赖 = () => ({
 describe('规划更新工作流', () => {
     it('隔离 onStreamDelta 消费端异常，避免打断规划分析流程', async () => {
         const workflow = 创建规划更新工作流(创建基础依赖());
+        const playerInput = '本轮只观察，不要安排刺客袭击。';
 
         await expect(workflow.后台执行统一规划分析({
             state: {
@@ -89,7 +91,7 @@ describe('规划更新工作流', () => {
                 剧情: {},
                 剧情规划: {}
             },
-            playerInput: '继续',
+            playerInput,
             gameTime: '辰时',
             response: { logs: [] } as any,
             onStreamDelta: () => {
@@ -99,6 +101,9 @@ describe('规划更新工作流', () => {
             updated: false,
             message: '无需更新',
             rawText: '累计文本'
+        });
+        expect(vi.mocked(textAIService.generatePlanningAnalysis).mock.calls.at(-1)?.[0]).toMatchObject({
+            playerInput
         });
     });
 });

--- a/__tests__/storyQualityAutoRetryE2E.test.ts
+++ b/__tests__/storyQualityAutoRetryE2E.test.ts
@@ -428,4 +428,149 @@ describe('主剧情质量审查自动重试端到端', () => {
         expect(finalText).toContain('我推开窗');
         expect(finalText).toContain('我没有追问');
     });
+
+    it('普通回合会把同一个 sendInput 传给动态世界和规划分析', async () => {
+        const body = [
+            '我停在巷口，没有贸然追上去，只隔着雨幕观察黑衣人的去向。',
+            '雨水顺着屋檐连成细线，遮住远处灯火，也让巷道里的脚步声变得断续难辨。',
+            '我只把手按在剑柄上，记下对方拐入西侧窄巷的方向，没有让自己贸然卷入新的冲突。'
+        ].join('\n');
+        vi.mocked(textAIService.generateStoryResponse)
+            .mockResolvedValueOnce(构建响应(body, '<正文>观察正文</正文>') as any);
+
+        let history: any[] = [];
+        const playerInput = '本轮只观察，不要推进主线，也不要安排刺客袭击。';
+        const apiConfig = {
+            activeConfigId: 'main',
+            configs: [{
+                id: 'main',
+                名称: '主剧情测试接口',
+                供应商: 'openai_compatible',
+                协议覆盖: 'openai',
+                baseUrl: 'https://example.test/v1',
+                apiKey: 'test-key',
+                model: 'test-model',
+                maxTokens: 1200,
+                temperature: 0.2
+            }],
+            功能模型占位: {
+                主剧情使用模型: 'test-model',
+                世界演变功能启用: true,
+                规划分析功能启用: true,
+                地图生成功能启用: false,
+                变量计算独立模型开关: false,
+                文章优化独立模型开关: false,
+                文生图功能启用: false,
+                NPC生图启用: false,
+                场景生图启用: false,
+                物品生图启用: false
+            }
+        };
+        const gameConfig = {
+            ...默认游戏设置,
+            字数要求: 50,
+            字数不足处理方式: '重新生成',
+            叙事人称: '第一人称',
+            启用自动重试: false,
+            启用行动选项: false,
+            启用回合结束自动存档: false,
+            启用正文词汇审查: false
+        };
+        const state = {
+            历史记录: history,
+            记忆系统: {},
+            角色: { 姓名: '端测少侠', 物品列表: [], 装备: {} },
+            环境: { 时间: '1:01:01:08:00', 大地点: '端测州', 具体地点: '雨巷' },
+            社交: [],
+            世界: { 地图层级: [] },
+            战斗: {},
+            玩家门派: {},
+            任务列表: [],
+            约定列表: [],
+            剧情: {},
+            剧情规划: {},
+            女主剧情规划: undefined,
+            同人剧情规划: undefined,
+            同人女主剧情规划: undefined,
+            开局配置: undefined,
+            游戏初始时间: '1:01:01:08:00',
+            loading: false,
+            gameConfig,
+            apiConfig,
+            memoryConfig: {},
+            visualConfig: {},
+            sceneImageArchive: {},
+            prompts: [],
+            内置提示词列表: [],
+            世界书列表: []
+        } as any;
+        const deps = {
+            abortControllerRef: { current: null },
+            recallAbortControllerRef: { current: null },
+            前台发送序号Ref: { current: 0 },
+            setLoading: vi.fn(),
+            set后台队列处理中: vi.fn(),
+            setShowSettings: vi.fn(),
+            设置剧情: vi.fn(),
+            设置历史记录: vi.fn((value: any) => {
+                history = typeof value === 'function' ? value(history) : value;
+            }),
+            设置叙事平静值: vi.fn(),
+            应用并同步记忆系统: vi.fn(),
+            构建系统提示词: vi.fn(() => 构建系统上下文()),
+            processResponseCommands: vi.fn((_response: any, baseState: any) => ({
+                ...深拷贝(baseState),
+                gameConfig,
+                剧情规划: baseState?.剧情规划 || {},
+                女主剧情规划: baseState?.女主剧情规划,
+                同人剧情规划: baseState?.同人剧情规划,
+                同人女主剧情规划: baseState?.同人女主剧情规划
+            })),
+            performAutoSave: vi.fn(async () => undefined),
+            执行正文润色: vi.fn(async (baseResponse: any, rawText: string) => ({ response: baseResponse, applied: false, rawText })),
+            执行世界演变更新: vi.fn(async () => ({ ok: true, phase: 'applied', statusText: '完成', commands: [], rawText: '' })),
+            触发新增NPC自动生图: vi.fn(),
+            触发对白NPC头像补全: vi.fn(),
+            检查主角每回合生图: vi.fn(),
+            触发场景自动生图: vi.fn(),
+            应用常驻壁纸为背景: vi.fn(async () => undefined),
+            提取新增NPC列表: vi.fn(() => []),
+            推入重Roll快照: vi.fn(),
+            弹出重Roll快照: vi.fn(),
+            回档到快照: vi.fn(),
+            深拷贝,
+            按回合窗口裁剪历史: (items: any[]) => items,
+            规范化环境信息: (value?: any) => value || {},
+            规范化剧情状态: (value?: any) => value || {},
+            规范化剧情规划状态: (value?: any) => value || {},
+            规范化女主剧情规划状态: (value?: any) => value,
+            规范化同人剧情规划状态: (value?: any) => value,
+            规范化同人女主剧情规划状态: (value?: any) => value,
+            规范化世界状态: (value?: any) => value || { 地图层级: [] },
+            游戏设置启用自动重试: (config?: any) => config?.启用自动重试 === true,
+            执行带自动重试的生成请求: async ({ action }: any) => action(1, null),
+            更新流式草稿为自动重试提示: (items: any[]) => items,
+            提取解析失败原始信息: (error: any) => error?.message || '',
+            提取原始报错详情: (error: any) => error?.message || '',
+            格式化错误详情: (error: any) => error?.message || '',
+            获取原始AI消息: (rawText: string) => rawText,
+            估算消息Token: () => 0,
+            估算AI输出Token: () => 0,
+            计算回复耗时秒: () => 1,
+            文章优化功能已开启: () => false,
+            后台执行统一规划分析: vi.fn(async () => ({ updated: false, message: '跳过', rawText: '', commands: [] })),
+            后台执行变量生成: vi.fn(async () => undefined),
+            执行变量生成并合并响应: vi.fn(async () => null)
+        } as any;
+
+        const result = await 执行主剧情发送工作流(playerInput, false, state, deps);
+        await vi.waitFor(() => {
+            expect(deps.执行世界演变更新).toHaveBeenCalled();
+            expect(deps.后台执行统一规划分析).toHaveBeenCalled();
+        });
+
+        expect(result.cancelled).not.toBe(true);
+        expect(vi.mocked(deps.执行世界演变更新).mock.calls.at(-1)?.[0]).toMatchObject({ playerInput });
+        expect(vi.mocked(deps.后台执行统一规划分析).mock.calls.at(-1)?.[0]).toMatchObject({ playerInput });
+    });
 });

--- a/__tests__/worldEvolutionEvents.test.ts
+++ b/__tests__/worldEvolutionEvents.test.ts
@@ -188,4 +188,31 @@ describe('worldEvolution visible events', () => {
         expect(context).toContain('势力补录：正文提到疑似新势力');
         expect(context).toContain('push 世界.势力列表');
     });
+
+    it('injects current player input as intent constraints without treating it as body facts', () => {
+        const context = 构建世界演变上下文文本({
+            playerInput: '本轮只观察，不要让追兵立刻袭击。',
+            currentTurnBody: '主角停在茶棚外观察雨势。',
+            currentTurnPlanText: '',
+            currentTurnCommandsText: ''
+        });
+
+        expect(context).toContain('【本轮玩家原始指令】');
+        expect(context).toContain('本轮只观察，不要让追兵立刻袭击。');
+        expect(context).toContain('不代表这些内容已经发生');
+        expect(context).toContain('对“不要、暂缓、仅观察、禁止推进”等限制应予以尊重');
+        expect(context).toContain('【本回合前台已发生事实】\n主角停在茶棚外观察雨势。');
+    });
+
+    it('omits player input block when current player input is empty', () => {
+        const context = 构建世界演变上下文文本({
+            playerInput: '   ',
+            currentTurnBody: '主角停在茶棚外观察雨势。',
+            currentTurnPlanText: '',
+            currentTurnCommandsText: ''
+        });
+
+        expect(context).not.toContain('【本轮玩家原始指令】');
+        expect(context).not.toContain('【玩家原始指令使用说明】');
+    });
 });

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -3118,6 +3118,7 @@ export const useGame = () => {
 
     const 执行世界演变更新 = async (params?: {
         来源?: 'manual' | 'auto_due' | 'story_dynamic' | 'story_dynamic_and_due';
+        playerInput?: string;
         动态世界线索?: string[];
         到期摘要?: string[];
         force?: boolean;

--- a/hooks/useGame/historyTurnWorkflow.ts
+++ b/hooks/useGame/historyTurnWorkflow.ts
@@ -77,6 +77,7 @@ type 历史回合工作流依赖 = {
     世界演变功能已开启: () => boolean;
     执行世界演变更新?: (params?: {
         来源?: 'manual' | 'auto_due' | 'story_dynamic' | 'story_dynamic_and_due';
+        playerInput?: string;
         动态世界线索?: string[];
         到期摘要?: string[];
         force?: boolean;
@@ -694,6 +695,7 @@ export const 创建历史回合工作流 = (deps: 历史回合工作流依赖) =
                 options?.onWorldEvolutionProgress?.({ phase: 'start', text: '正在重新执行动态世界更新...' });
                 const result = await deps.执行世界演变更新({
                     来源: 'story_dynamic',
+                    playerInput,
                     动态世界线索: [],
                     applyCommands: true,
                     currentResponse: parsed,

--- a/hooks/useGame/planningUpdateWorkflow.ts
+++ b/hooks/useGame/planningUpdateWorkflow.ts
@@ -564,6 +564,7 @@ export const 创建规划更新工作流 = (deps: 规划更新工作流依赖) =
         const 规划分析非流式输出 = normalizedGameConfig.启用非流式输出 || normalizedGameConfig.功能模型占位?.规划分析非流式输出;
         const result = await probe.timeAsync('规划分析模型请求总耗时', () => 执行规划分析带超时和重试((signal, markStreamActivity) => textAIService.generatePlanningAnalysis({
             playerName: (deps.角色?.姓名 || '').trim() || '未命名',
+            playerInput: params.playerInput,
             currentStoryJson,
             currentHeroinePlanJson,
             worldJson,

--- a/hooks/useGame/sendWorkflow.ts
+++ b/hooks/useGame/sendWorkflow.ts
@@ -2641,6 +2641,7 @@ export const 执行主剧情发送工作流 = async (
                             };
                             const result = await deps.执行世界演变更新({
                                 来源: "story_dynamic",
+                                playerInput: sendInput,
                                 动态世界线索: [],
                                 applyCommands: false,
                                 currentResponse: worldContextResponse,

--- a/hooks/useGame/worldEvolutionControl.ts
+++ b/hooks/useGame/worldEvolutionControl.ts
@@ -19,6 +19,7 @@ type 世界演变控制依赖 = {
     规范化世界状态: (raw?: any) => any;
     执行世界演变更新: (params?: {
         来源?: 'manual' | 'auto_due' | 'story_dynamic' | 'story_dynamic_and_due';
+        playerInput?: string;
         动态世界线索?: string[];
         到期摘要?: string[];
         force?: boolean;

--- a/hooks/useGame/worldEvolutionUtils.ts
+++ b/hooks/useGame/worldEvolutionUtils.ts
@@ -477,6 +477,7 @@ export const 构建世界演变上下文文本 = (params: {
     storyData?: unknown;
     shortMemoryTexts?: string[];
     scriptText?: string;
+    playerInput?: string;
     currentTurnBody?: string;
     currentTurnPlanText?: string;
     currentTurnCommandsText?: string;
@@ -490,6 +491,7 @@ export const 构建世界演变上下文文本 = (params: {
         .filter(Boolean)
         .join('\n') || '暂无';
     const scriptBlock = (params.scriptText || '').trim() || '暂无';
+    const playerInput = (params.playerInput || '').trim();
     const currentTurnBody = (params.currentTurnBody || '').trim() || '暂无';
     const currentTurnPlanText = (params.currentTurnPlanText || '').trim() || '无';
     const currentTurnCommandsText = (params.currentTurnCommandsText || '').trim() || '无';
@@ -529,6 +531,16 @@ export const 构建世界演变上下文文本 = (params: {
         '【当前剧情锚点】',
         序列化世界演变展示上下文(提炼世界演变剧情锚点(params.storyData)),
         '',
+        ...(playerInput ? [
+            '【本轮玩家原始指令】',
+            playerInput,
+            '',
+            '【玩家原始指令使用说明】',
+            '- 这是玩家本轮的意图、要求和限制，不代表这些内容已经发生。',
+            '- 必须结合本轮最终正文、已落地命令和当前状态判断哪些事实真正成立。',
+            '- 对“不要、暂缓、仅观察、禁止推进”等限制应予以尊重。',
+            ''
+        ] : []),
         '【本回合前台已发生事实】',
         currentTurnBody,
         '',

--- a/hooks/useGame/worldEvolutionWorkflow.ts
+++ b/hooks/useGame/worldEvolutionWorkflow.ts
@@ -23,6 +23,7 @@ import { 执行游戏后台重计算 } from '../../utils/gameHeavyWorkerClient';
 
 export type 世界演变触发参数 = {
     来源?: 'manual' | 'auto_due' | 'story_dynamic' | 'story_dynamic_and_due';
+    playerInput?: string;
     动态世界线索?: string[];
     到期摘要?: string[];
     force?: boolean;
@@ -298,8 +299,10 @@ export const 执行世界演变更新工作流 = async (
         const currentTurnCommandsText = probe.time('序列化当前回合命令', () => 序列化上下文命令(params?.currentResponse?.tavern_commands || []), {
             commandCount: Array.isArray(params?.currentResponse?.tavern_commands) ? params.currentResponse.tavern_commands.length : 0
         });
+        const playerInput = typeof params?.playerInput === 'string' ? params.playerInput.trim() : '';
         const envCanonical = 环境时间转标准串(worldStateBase?.环境 || deps.环境) || '';
         probe.mark('世界演变基础上下文准备完成', {
+            playerInputLength: playerInput.length,
             scriptLength: worldScriptText.length,
             currentBodyLength: currentTurnBody.length,
             currentPlanLength: currentTurnPlanText.length,
@@ -309,6 +312,7 @@ export const 执行世界演变更新工作流 = async (
         const signature = [
             triggerSource,
             envCanonical,
+            playerInput,
             dynamicHints.join('|'),
             dueHints.join('|'),
             currentTurnBody,
@@ -332,6 +336,7 @@ export const 执行世界演变更新工作流 = async (
             storyData: worldStory,
             shortMemoryTexts: worldShortMemoryTexts,
             scriptText: worldScriptText,
+            playerInput,
             currentTurnBody,
             currentTurnPlanText,
             currentTurnCommandsText,
@@ -355,7 +360,7 @@ export const 执行世界演变更新工作流 = async (
             environment: worldEnv,
             world: worldState,
             history: worldHistory,
-            extraTexts: [currentTurnBody, currentTurnPlanText, currentTurnCommandsText, ...dynamicHints, ...dueHints]
+            extraTexts: [playerInput, currentTurnBody, currentTurnPlanText, currentTurnCommandsText, ...dynamicHints, ...dueHints]
         };
         const worldbookExtraPrompt = await probe.timeAsync('构建世界演变世界书注入(worker)', () => 执行游戏后台重计算<string>(
             'buildWorldbookText',

--- a/prompts/runtime/planningAnalysis.ts
+++ b/prompts/runtime/planningAnalysis.ts
@@ -121,6 +121,7 @@ export const 构建统一规划分析系统提示词 = (options?: { heroineEnabl
 };
 
 export const 构建统一规划分析用户提示词 = (params: {
+    playerInput?: string;
     currentStoryJson: string;
     currentHeroinePlanJson: string;
     worldJson: string;
@@ -131,7 +132,9 @@ export const 构建统一规划分析用户提示词 = (params: {
     auditFocusText: string;
     genderRatioConstraintText?: string;
     heroineEnabled?: boolean;
-}): string => [
+}): string => {
+    const playerInput = (params.playerInput || '').trim();
+    return [
     '【当前章节状态与当前激活主线规划树】',
     params.currentStoryJson,
     '',
@@ -149,6 +152,17 @@ export const 构建统一规划分析用户提示词 = (params: {
     '【当前环境】',
     params.envJson,
     '',
+    ...(playerInput ? [
+        '【本轮玩家原始指令】',
+        playerInput,
+        '',
+        '【玩家原始指令使用说明】',
+        '- 这是玩家本轮意图与约束，不代表已经发生，也不是已发生事实。',
+        '- 应以最终正文和已落地状态判断事实。',
+        '- 不得违背玩家明确提出的“不要、暂缓、禁止、只观察”等限制。',
+        '- 不应因为玩家表达想法，就直接把它安排为已完成或已触发事件。',
+        ''
+    ] : []),
     (params.genderRatioConstraintText || '').trim()
         ? params.genderRatioConstraintText.trim()
         : '【规划性别比例约束】\n- 当前上下文未注入明确比例；若当前世界状态中存在世界观/NPC系统男女比例或性别比例设定，仍需在新增人物池时读取并遵守。',
@@ -193,4 +207,5 @@ export const 构建统一规划分析用户提示词 = (params: {
     params.recentBodiesText,
     '',
     '任务：基于本回合已发生事实，统一分析章节状态、当前激活主线规划树、当前激活女主规划树与当前世界状态是否需要同步修订、清理、迁移、补承接或切章。只输出最小补丁命令。'
-].join('\n');
+    ].join('\n');
+};

--- a/services/ai/storyTasks.ts
+++ b/services/ai/storyTasks.ts
@@ -1781,6 +1781,7 @@ const 规范化新小说拆分物品档案 = (raw: any): NovelDecompositionItemP
 const 构建规划分析消息链 = (
     params: {
         playerName: string;
+        playerInput?: string;
         currentStoryJson: string;
         currentHeroinePlanJson: string;
         worldJson: string;
@@ -1789,6 +1790,7 @@ const 构建规划分析消息链 = (
         recentBodiesText: string;
         currentPlanText?: string;
         auditFocusText: string;
+        genderRatioConstraintText?: string;
         heroineEnabled?: boolean;
         ntlEnabled?: boolean;
         fandomEnabled?: boolean;
@@ -1804,6 +1806,7 @@ const 构建规划分析消息链 = (
     const fandomCotPrompt = params.fandomEnabled ? 同人规划分析附加COT提示词 : '';
     const taskPrompt = [
         `【本次任务】\n${构建统一规划分析用户提示词({
+            playerInput: params.playerInput,
             currentStoryJson: params.currentStoryJson,
             currentHeroinePlanJson: params.currentHeroinePlanJson,
             worldJson: params.worldJson,
@@ -1843,6 +1846,7 @@ const 构建规划分析消息链 = (
 export const generatePlanningAnalysis = async (
     params: {
         playerName: string;
+        playerInput?: string;
         currentStoryJson: string;
         currentHeroinePlanJson: string;
         worldJson: string;


### PR DESCRIPTION
修复动态世界与规划分析未充分读取玩家本轮原始指令的问题。

## 问题原因

当前主正文生成阶段会直接读取玩家本轮输入，但后续两个阶段存在数据流缺口：

- 动态世界阶段此前没有独立接收玩家本轮原始指令，只能从正文、规划、命令和历史内容中间接推断。
- 规划分析阶段虽然上层参数中存在 `playerInput`，但没有继续传入最终的规划分析 prompt，也没有以独立语义区块呈现。
- 当最终正文没有完整复述玩家提出的“不要、暂缓、只观察、禁止推进”等要求时，动态世界和规划分析可能忽略这些限制，继续安排不符合玩家意图的事件。

## 修改内容

- 为动态世界流程补充 `playerInput` 参数传递。
- 普通回合会将本轮 `sendInput` 传入动态世界。
- 单阶段重试会恢复对应历史回合的玩家输入。
- 动态世界 prompt 新增独立区块：`【本轮玩家原始指令】`。
- 规划分析将已有 `playerInput` 继续传入 `generatePlanningAnalysis`。
- 规划分析 prompt 同样新增独立的玩家原始指令区块。
- 两处 prompt 都明确说明：
  - 玩家输入代表本轮意图、要求和限制；
  - 不代表内容已经发生；
  - 必须结合最终正文、已落地命令和当前状态判断事实；
  - 应尊重“不要、暂缓、只观察、禁止推进”等明确限制。
- 玩家输入不会被拼进正文、历史脚本或已发生事实区域。

## 未修改内容

本 PR 不改变：

- 动态世界的业务职责；
- 规划分析的业务职责；
- 世界演变触发条件；
- 命令过滤与命令应用逻辑；
- 自动重试结构；
- 并行 / 串行后处理结构；
- 主正文生成逻辑；
- 变量生成逻辑；
- 存档结构；
- 开局流程。

## 测试

`npm run test:run -- __tests__/worldEvolutionEvents.test.ts __tests__/planningPrompts.test.ts __tests__/planningUpdateWorkflow.test.ts __tests__/historyTurnVariableRetry.test.ts __tests__/storyQualityAutoRetryE2E.test.ts`

结果：

- 5 个测试文件通过；
- 22 个测试通过。

`npm run build`

构建通过。

## 手动验收建议

- 输入“本回合只观察情况，不要让敌人发动袭击，也不要推进主线”。
- 确认动态世界不会安排敌人袭击。
- 确认规划分析不会补充主线推进。
- 输入“暂停推进主线，先休整疗伤”。
- 确认规划分析会尊重暂缓要求，而不是继续切章。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 世界演变与规划分析现在会结合本回合玩家的原始指令，生成更贴合当前意图的内容。
  - 玩家指令会作为行动约束参考，不会被误判为已经发生的剧情事实。
  - 重试世界演变阶段时会保留本回合输入，确保重试结果与原始操作一致。
  - 空白输入不会产生多余的提示内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->