### PR TITLE
小补丁：生图防炸

### DIFF
--- a/__tests__/prebootErrorHandling.test.ts
+++ b/__tests__/prebootErrorHandling.test.ts
@@ -88,6 +88,19 @@ describe('preboot error handling', () => {
         expect(appended).toHaveLength(1);
     });
 
+    it('does not hide a structured HTTP 401 rejection containing API Error text', () => {
+        const { listeners, appended } = loadPrebootListeners();
+        const preventDefault = vi.fn();
+
+        listeners.unhandledrejection({
+            reason: { message: 'API Error: Unauthorized', status: 401 },
+            preventDefault
+        });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+        expect(appended).toHaveLength(1);
+    });
+
     it('still shows the startup failure overlay for non-recoverable promise rejections', () => {
         const { listeners, appended } = loadPrebootListeners();
 

--- a/__tests__/prebootErrorHandling.test.ts
+++ b/__tests__/prebootErrorHandling.test.ts
@@ -49,6 +49,45 @@ describe('preboot error handling', () => {
         expect(windowMock.__MORAN_PREBOOT_LOGS__[0].level).toBe('warn');
     });
 
+    it('treats structured HTTP 5xx status as recoverable', () => {
+        const { listeners, appended } = loadPrebootListeners();
+        const preventDefault = vi.fn();
+
+        listeners.unhandledrejection({
+            reason: { message: 'upstream failed', status: 503 },
+            preventDefault
+        });
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(appended).toHaveLength(0);
+    });
+
+    it('treats contextual HTTP 502 text as recoverable', () => {
+        const { listeners, appended } = loadPrebootListeners();
+        const preventDefault = vi.fn();
+
+        listeners.unhandledrejection({
+            reason: new Error('API proxy returned HTTP 502 Bad Gateway'),
+            preventDefault
+        });
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(appended).toHaveLength(0);
+    });
+
+    it('does not treat bare 5xx-looking business numbers as recoverable', () => {
+        const { listeners, appended } = loadPrebootListeners();
+        const preventDefault = vi.fn();
+
+        listeners.unhandledrejection({
+            reason: new Error('inventory item 512 failed validation at line 550'),
+            preventDefault
+        });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+        expect(appended).toHaveLength(1);
+    });
+
     it('still shows the startup failure overlay for non-recoverable promise rejections', () => {
         const { listeners, appended } = loadPrebootListeners();
 

--- a/index.html
+++ b/index.html
@@ -50,9 +50,47 @@
         return false;
       }
 
+      function readStructuredHttpStatus(reason) {
+        if (!reason || typeof reason !== 'object') return null;
+        function asStatus(value) {
+          var n = Number(value);
+          if (!isFinite(n)) return null;
+          n = Math.floor(n);
+          if (n >= 100 && n <= 599) return n;
+          return null;
+        }
+        var status = asStatus(reason.status);
+        if (status != null) return status;
+        status = asStatus(reason.statusCode);
+        if (status != null) return status;
+        if (reason.response && typeof reason.response === 'object') {
+          status = asStatus(reason.response.status);
+          if (status != null) return status;
+        }
+        return null;
+      }
+
+      function isRecoverableHttpStatus(status) {
+        if (status == null) return false;
+        // 408/429/5xx 视为可恢复网络侧失败，不挡启动
+        return status === 408 || status === 429 || (status >= 500 && status <= 599);
+      }
+
       function isRecoverableNetworkRejection(reason) {
+        if (isRecoverableHttpStatus(readStructuredHttpStatus(reason))) return true;
         var text = stringify(reason);
-        return /NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed|API Error|upstream_error|upstream_status|5\d{2}|rate_limit|bad_response_status_code/i.test(text);
+        if (/NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed/i.test(text)) {
+          return true;
+        }
+        // 明确的 API/上游错误类型关键字（非裸数字）
+        if (/\b(?:API Error|upstream_error|rate_limit|bad_response_status_code)\b/i.test(text)) {
+          return true;
+        }
+        // 文本 fallback 必须带 HTTP 状态上下文，避免 stack/行号/业务数字误伤
+        if (/(?:\bHTTP\b|\bstatus(?:Code)?\b|\bupstream_status\b)[^0-9]{0,12}\b(?:408|429|5\d{2})\b/i.test(text)) {
+          return true;
+        }
+        return false;
       }
 
       function showOverlay() {

--- a/index.html
+++ b/index.html
@@ -77,7 +77,8 @@
       }
 
       function isRecoverableNetworkRejection(reason) {
-        if (isRecoverableHttpStatus(readStructuredHttpStatus(reason))) return true;
+        var status = readStructuredHttpStatus(reason);
+        if (status != null) return isRecoverableHttpStatus(status);
         var text = stringify(reason);
         if (/NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed/i.test(text)) {
           return true;

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 
       function isRecoverableNetworkRejection(reason) {
         var text = stringify(reason);
-        return /NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed/i.test(text);
+        return /NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed|API Error|upstream_error|upstream_status|5\d{2}|rate_limit|bad_response_status_code/i.test(text);
       }
 
       function showOverlay() {

--- a/services/diagnosticLog.ts
+++ b/services/diagnosticLog.ts
@@ -17,10 +17,6 @@ type PrebootLogEntry = {
     values?: unknown[];
 };
 
-const isRecoverableNetworkRejection = (reason: unknown): boolean => (
-    /NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed|API Error|upstream_error|upstream_status|5\d{2}|rate_limit|bad_response_status_code/i.test(stringifyValue(reason))
-);
-
 declare global {
     interface Window {
         __MORAN_PREBOOT_LOGS__?: PrebootLogEntry[];
@@ -62,6 +58,51 @@ const stringifyValue = (value: unknown): string => {
         return truncateString(String(value), MAX_RENDERED_VALUE_CHARS);
     }
 };
+
+const readStructuredHttpStatus = (reason: unknown): number | null => {
+    if (!reason || typeof reason !== 'object') return null;
+    const asStatus = (value: unknown): number | null => {
+        const n = Number(value);
+        if (!Number.isFinite(n)) return null;
+        const status = Math.floor(n);
+        if (status >= 100 && status <= 599) return status;
+        return null;
+    };
+    const record = reason as Record<string, unknown>;
+    const direct = asStatus(record.status) ?? asStatus(record.statusCode);
+    if (direct != null) return direct;
+    const response = record.response;
+    if (response && typeof response === 'object') {
+        const nested = asStatus((response as Record<string, unknown>).status);
+        if (nested != null) return nested;
+    }
+    return null;
+};
+
+const isRecoverableHttpStatus = (status: number | null): boolean => {
+    if (status == null) return false;
+    // 408/429/5xx 视为可恢复网络侧失败，不吞掉非网络异常
+    return status === 408 || status === 429 || (status >= 500 && status <= 599);
+};
+
+const isRecoverableNetworkRejection = (reason: unknown): boolean => {
+    if (isRecoverableHttpStatus(readStructuredHttpStatus(reason))) return true;
+    const text = stringifyValue(reason);
+    if (/NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed/i.test(text)) {
+        return true;
+    }
+    // 明确的 API/上游错误类型关键字（非裸数字）
+    if (/\b(?:API Error|upstream_error|rate_limit|bad_response_status_code)\b/i.test(text)) {
+        return true;
+    }
+    // 文本 fallback 必须带 HTTP 状态上下文，避免 stack/行号/业务数字误伤
+    if (/(?:\bHTTP\b|\bstatus(?:Code)?\b|\bupstream_status\b)[^0-9]{0,12}\b(?:408|429|5\d{2})\b/i.test(text)) {
+        return true;
+    }
+    return false;
+};
+
+
 
 const emit = () => {
     listeners.forEach(listener => {

--- a/services/diagnosticLog.ts
+++ b/services/diagnosticLog.ts
@@ -86,7 +86,8 @@ const isRecoverableHttpStatus = (status: number | null): boolean => {
 };
 
 const isRecoverableNetworkRejection = (reason: unknown): boolean => {
-    if (isRecoverableHttpStatus(readStructuredHttpStatus(reason))) return true;
+    const status = readStructuredHttpStatus(reason);
+    if (status != null) return isRecoverableHttpStatus(status);
     const text = stringifyValue(reason);
     if (/NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed/i.test(text)) {
         return true;

--- a/services/diagnosticLog.ts
+++ b/services/diagnosticLog.ts
@@ -18,7 +18,7 @@ type PrebootLogEntry = {
 };
 
 const isRecoverableNetworkRejection = (reason: unknown): boolean => (
-    /NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed/i.test(stringifyValue(reason))
+    /NetworkError when attempting to fetch resource|Failed to fetch|Load failed|The Internet connection appears to be offline|Network request failed|API Error|upstream_error|upstream_status|5\d{2}|rate_limit|bad_response_status_code/i.test(stringifyValue(reason))
 );
 
 declare global {


### PR DESCRIPTION
以前的生图逻辑不防5xx类型错误，出现时候会炸了游戏。现已修复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 扩大了可恢复网络错误的识别：优先根据错误中的结构化 HTTP 状态码判断（408/429/5xx），并结合更多上游异常、限流与响应错误语义进行综合判定。
  * 降低误判：仅在错误内容带有明确 HTTP/状态语境时才会触发可恢复逻辑，从而减少不必要的启动失败覆盖层或误导性提示。
  * 新增/强化 `unhandledrejection` 测试用例，覆盖结构化状态码与相似文案的区分场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->