### PR TITLE
修复流式中断、严格格式与设置模块回归

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import InputArea from './components/features/Chat/InputArea';
 import LandingPage from './components/layout/LandingPage';
 import InAppConfirmModal, { ConfirmOptions } from './components/ui/InAppConfirmModal';
 import ReleaseNotesModal from './components/ui/ReleaseNotesModal';
+import { ModalErrorBoundary } from './components/ui/ModalErrorBoundary';
 import { useGame } from './hooks/useGame';
 import { use图片资源回源预取 } from './hooks/useImageAssetPrefetch';
 import { normalizeCanonicalGameTime, 环境时间转标准串 } from './hooks/useGame/timeUtils';
@@ -442,62 +443,6 @@ const 懒加载边界: React.FC<{ children: React.ReactNode }> = ({ children }) 
     <React.Suspense fallback={<懒加载占位 />}>{children}</React.Suspense>
 );
 
-
-class ModalErrorBoundary extends React.Component<
-    { children: React.ReactNode; title: string; onClose?: () => void },
-    { error: Error | null }
-> {
-    state: { error: Error | null } = { error: null };
-
-    static getDerivedStateFromError(error: Error) {
-        return { error };
-    }
-
-    componentDidCatch(error: Error) {
-        console.error('Modal render failed:', error);
-    }
-
-    render() {
-        if (!this.state.error) {
-            return this.props.children;
-        }
-
-        const isLazyImportError = isDynamicImportFetchError(this.state.error);
-        return (
-            <div className="fixed inset-0 z-[280] flex items-center justify-center bg-black/88 px-5 py-8">
-                <div className="w-full max-w-md rounded-2xl border border-red-500/45 bg-[#120909] p-5 text-red-100 shadow-[0_20px_60px_rgba(0,0,0,0.7)]">
-                    <div className="text-base font-semibold tracking-[0.12em] text-red-200">{this.props.title}</div>
-                    <div className="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-red-100/90">
-                        {this.state.error.message || '界面渲染失败'}
-                    </div>
-                    <div className="mt-4 text-xs leading-5 text-red-200/70">
-                        {isLazyImportError
-                            ? '检测到页面资源已经更新，但当前页面还停留在旧版本。点击下面按钮刷新后，通常就能直接恢复。'
-                            : '这次错误已写入运行日志。可打开"设置 → 运行日志"查看详情、复制诊断或点击"上报日志"提交给维护人员。'}
-                    </div>
-                    {isLazyImportError && (
-                        <button
-                            type="button"
-                            onClick={() => window.location.reload()}
-                            className="mt-5 inline-flex h-10 items-center justify-center rounded-lg border border-wuxia-gold/35 bg-wuxia-gold/10 px-4 text-sm text-wuxia-gold"
-                        >
-                            刷新重试
-                        </button>
-                    )}
-                    {this.props.onClose && (
-                        <button
-                            type="button"
-                            onClick={this.props.onClose}
-                            className="mt-5 inline-flex h-10 items-center justify-center rounded-lg border border-red-300/40 bg-red-950/40 px-4 text-sm text-red-50"
-                        >
-                            关闭
-                        </button>
-                    )}
-                </div>
-            </div>
-        );
-    }
-}
 
 const App: React.FC = () => {
     const { state, meta, setters, actions } = useGame();

--- a/App.tsx
+++ b/App.tsx
@@ -3688,6 +3688,7 @@ const App: React.FC = () => {
             {/* Settings Modal */}
             {state.showSettings && (
                 <div className={desktopRightDetailClass}>
+                <ModalErrorBoundary title="设置打开失败" onClose={closeSettings}>
                 <懒加载边界>
                     {isMobile ? (
                         <MobileSettingsModal
@@ -3785,6 +3786,7 @@ const App: React.FC = () => {
                         />
                     )}
                 </懒加载边界>
+                </ModalErrorBoundary>
                 </div>
             )}
 

--- a/__tests__/settingsLazyImportBoundary.test.ts
+++ b/__tests__/settingsLazyImportBoundary.test.ts
@@ -1,6 +1,32 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ModalErrorBoundary } from '../components/ui/ModalErrorBoundary';
+import { lazyImportWithReload } from '../utils/lazyImportWithReload';
+
+const 读取节点文本 = (node: React.ReactNode): string => {
+    if (typeof node === 'string' || typeof node === 'number') return String(node);
+    if (Array.isArray(node)) return node.map(读取节点文本).join('');
+    if (!React.isValidElement(node)) return '';
+    return 读取节点文本((node.props as { children?: React.ReactNode }).children);
+};
+
+const 查找按钮点击 = (node: React.ReactNode, label: string): (() => void) | null => {
+    if (Array.isArray(node)) {
+        for (const child of node) {
+            const found = 查找按钮点击(child, label);
+            if (found) return found;
+        }
+        return null;
+    }
+    if (!React.isValidElement(node)) return null;
+    const props = node.props as { children?: React.ReactNode; onClick?: () => void };
+    if (node.type === 'button' && 读取节点文本(props.children).includes(label)) {
+        return props.onClick || null;
+    }
+    return 查找按钮点击(props.children, label);
+};
 
 describe('设置模块懒加载局部错误边界', () => {
     it('settings-world 等旧 chunk 失效时由设置弹窗边界承接，不击穿根界面', () => {
@@ -25,5 +51,52 @@ describe('设置模块懒加载局部错误边界', () => {
         expect(desktopSettings).toBeGreaterThan(suspenseOpen);
         expect(suspenseClose).toBeGreaterThan(desktopSettings);
         expect(boundaryClose).toBeGreaterThan(suspenseClose);
+    });
+
+    it('动态导入失败时显示设置局部错误页，并可调用关闭设置而不影响边界外根界面', async () => {
+        const originalWindow = globalThis.window;
+        Object.defineProperty(globalThis, 'window', {
+            configurable: true,
+            value: {}
+        });
+
+        try {
+            const importError = await lazyImportWithReload(
+                'settings-world',
+                async () => Promise.reject(new Error('Failed to fetch dynamically imported module'))
+            ).then(
+                () => null,
+                (error: Error) => error
+            );
+            expect(importError?.name).toBe('DynamicImportDeferredReloadError');
+
+            const closeSettings = vi.fn();
+            const boundary = new ModalErrorBoundary({
+                title: '设置打开失败',
+                onClose: closeSettings,
+                children: React.createElement('div', null, '边界外根界面仍可使用')
+            });
+            boundary.state = ModalErrorBoundary.getDerivedStateFromError(importError as Error);
+
+            const fallback = boundary.render();
+            const fallbackText = 读取节点文本(fallback);
+            expect(fallbackText).toContain('设置打开失败');
+            expect(fallbackText).toContain('页面资源已经更新');
+            expect(fallbackText).toContain('刷新重试');
+
+            const closeClick = 查找按钮点击(fallback, '关闭');
+            expect(closeClick).toBeTypeOf('function');
+            closeClick?.();
+            expect(closeSettings).toHaveBeenCalledTimes(1);
+        } finally {
+            if (originalWindow === undefined) {
+                delete (globalThis as { window?: Window }).window;
+            } else {
+                Object.defineProperty(globalThis, 'window', {
+                    configurable: true,
+                    value: originalWindow
+                });
+            }
+        }
     });
 });

--- a/__tests__/settingsLazyImportBoundary.test.ts
+++ b/__tests__/settingsLazyImportBoundary.test.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('设置模块懒加载局部错误边界', () => {
+    it('settings-world 等旧 chunk 失效时由设置弹窗边界承接，不击穿根界面', () => {
+        const source = fs.readFileSync(path.join(process.cwd(), 'App.tsx'), 'utf8');
+        const settingsBlockStart = source.indexOf('{/* Settings Modal */}');
+        const settingsBlockEnd = source.indexOf('{showWorldbookManager && (', settingsBlockStart);
+
+        expect(settingsBlockStart).toBeGreaterThanOrEqual(0);
+        expect(settingsBlockEnd).toBeGreaterThan(settingsBlockStart);
+
+        const settingsBlock = source.slice(settingsBlockStart, settingsBlockEnd);
+        const boundaryOpen = settingsBlock.indexOf('<ModalErrorBoundary title="设置打开失败" onClose={closeSettings}>');
+        const suspenseOpen = settingsBlock.indexOf('<懒加载边界>');
+        const mobileSettings = settingsBlock.indexOf('<MobileSettingsModal');
+        const desktopSettings = settingsBlock.indexOf('<SettingsModal');
+        const suspenseClose = settingsBlock.lastIndexOf('</懒加载边界>');
+        const boundaryClose = settingsBlock.lastIndexOf('</ModalErrorBoundary>');
+
+        expect(boundaryOpen).toBeGreaterThanOrEqual(0);
+        expect(suspenseOpen).toBeGreaterThan(boundaryOpen);
+        expect(mobileSettings).toBeGreaterThan(suspenseOpen);
+        expect(desktopSettings).toBeGreaterThan(suspenseOpen);
+        expect(suspenseClose).toBeGreaterThan(desktopSettings);
+        expect(boundaryClose).toBeGreaterThan(suspenseClose);
+    });
+});

--- a/__tests__/storyLengthValidation.test.ts
+++ b/__tests__/storyLengthValidation.test.ts
@@ -236,6 +236,7 @@ describe('主剧情正文字数校验', () => {
                 境界体系提示词: '',
                 离场NPC档案: '',
                 otherPrompts: '',
+                文风提示词: '',
                 难度设置提示词: '',
                 叙事人称提示词: '',
                 字数设置提示词: '<字数>本次<正文>内的正文必须达到动态注入的最低字数要求。</字数>',
@@ -301,6 +302,7 @@ describe('主剧情正文字数校验', () => {
                 境界体系提示词: '',
                 离场NPC档案: '',
                 otherPrompts: '',
+                文风提示词: '',
                 难度设置提示词: '',
                 叙事人称提示词: '',
                 字数设置提示词: '<字数>旧字数提示会被运行时修正。</字数>',
@@ -328,6 +330,7 @@ describe('主剧情正文字数校验', () => {
             gameConfig: {
                 ...默认游戏设置,
                 字数要求: 2200,
+                启用严格正文对白格式: false,
                 启用酒馆预设模式: true,
                 当前酒馆预设ID: 'travel',
                 酒馆预设角色ID: 1,
@@ -373,6 +376,96 @@ describe('主剧情正文字数校验', () => {
         expect(result.orderedMessages.some((message) => message.content.includes('2200字以上'))).toBe(true);
         // 也不应注入项目输出协议和风格助手
         expect(result.orderedMessages.some((message) => message.content.includes('输出协议'))).toBe(false);
+        expect(result.messageEntries.some((entry) => entry.id === 'tavern_format_requirement')).toBe(false);
+
+        const strictResult = 构建主剧情请求参数({
+            gameConfig: {
+                ...默认游戏设置,
+                字数要求: 2200,
+                启用严格正文对白格式: true,
+                启用酒馆预设模式: true,
+                当前酒馆预设ID: 'travel',
+                酒馆预设角色ID: 1,
+                酒馆预设列表: [{
+                    id: 'travel',
+                    名称: '双人旅行',
+                    角色ID: 1,
+                    预设: {
+                        spec: 'chara_card_v3',
+                        prompts: [
+                            { identifier: 'main', name: 'main', role: 'system', content: '固定预设' },
+                            { identifier: 'worldInfoBefore', name: 'worldInfoBefore', role: 'system', content: '' },
+                            { identifier: 'userInput', name: 'userInput', role: 'user', content: '' }
+                        ],
+                        prompt_order: [{
+                            character_id: 1,
+                            order: [
+                                { identifier: 'main', enabled: true },
+                                { identifier: 'worldInfoBefore', enabled: true },
+                                { identifier: 'userInput', enabled: true }
+                            ]
+                        }]
+                    } as any
+                }]
+            },
+            apiConfig: {
+                apiKey: 'test-key',
+                baseUrl: 'https://example.test/v1',
+                model: 'gemini-test'
+            } as any,
+            builtContext,
+            updatedContextHistory: [],
+            updatedMemSys: {} as any,
+            sendInput: '继续剧情。'
+        });
+
+        expect(strictResult.messageEntries).toContainEqual(expect.objectContaining({
+            id: 'tavern_format_requirement',
+            role: 'system',
+            content: '<正文>...</正文>'
+        }));
+
+        const placeholderResult = 构建主剧情请求参数({
+            gameConfig: {
+                ...默认游戏设置,
+                字数要求: 2200,
+                启用严格正文对白格式: true,
+                启用酒馆预设模式: true,
+                当前酒馆预设ID: 'format-placeholder',
+                酒馆预设角色ID: 1,
+                酒馆预设列表: [{
+                    id: 'format-placeholder',
+                    名称: '格式占位预设',
+                    角色ID: 1,
+                    预设: {
+                        spec: 'chara_card_v3',
+                        prompts: [
+                            { identifier: 'main', name: 'main', role: 'system', content: '固定预设\n{{格式}}' },
+                            { identifier: 'userInput', name: 'userInput', role: 'user', content: '' }
+                        ],
+                        prompt_order: [{
+                            character_id: 1,
+                            order: [
+                                { identifier: 'main', enabled: true },
+                                { identifier: 'userInput', enabled: true }
+                            ]
+                        }]
+                    } as any
+                }]
+            },
+            apiConfig: {
+                apiKey: 'test-key',
+                baseUrl: 'https://example.test/v1',
+                model: 'gemini-test'
+            } as any,
+            builtContext,
+            updatedContextHistory: [],
+            updatedMemSys: {} as any,
+            sendInput: '继续剧情。'
+        });
+
+        expect(placeholderResult.messageEntries.some((entry) => entry.id === 'tavern_format_requirement')).toBe(false);
+        expect(placeholderResult.messageEntries.filter((entry) => entry.content.includes('<正文>...</正文>'))).toHaveLength(1);
     });
 
     it('酒馆预设使用 cot 占位符时仍保留时间和地点关键运行规则', () => {
@@ -391,6 +484,7 @@ describe('主剧情正文字数校验', () => {
                 境界体系提示词: '',
                 离场NPC档案: '',
                 otherPrompts: '',
+                文风提示词: '',
                 难度设置提示词: '',
                 叙事人称提示词: '',
                 字数设置提示词: '',

--- a/__tests__/streamPrematureEndFallback.test.ts
+++ b/__tests__/streamPrematureEndFallback.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { 请求模型文本, type 通用流式结束信息 } from '../services/ai/chatCompletionClient';
+import { generateStoryResponse } from '../services/ai/storyTasks';
+import { 判定主剧情重试流式策略, 是否流式意外终止错误, 流式意外终止降级提示 } from '../hooks/useGame/sendWorkflow';
+import type { 当前可用接口结构 } from '../utils/apiConfig';
+
+const baseConfig: 当前可用接口结构 = {
+    id: 'test',
+    名称: 'test',
+    供应商: 'openai_compatible',
+    协议覆盖: 'auto',
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'test-key',
+    model: 'test-model'
+};
+
+const 构建SSE流式响应 = (frames: string[], options?: { 发送DONE信号?: boolean }): Response => {
+    const payload = frames.map((frame) => `data: ${frame}\n\n`).join('')
+        + (options?.发送DONE信号 === false ? '' : 'data: [DONE]\n\n');
+    const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode(payload));
+            controller.close();
+        }
+    });
+    return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' }
+    });
+};
+
+const 完整协议帧 = (正文: string) => JSON.stringify({
+    choices: [{
+        delta: {
+            content: `<正文>\n【旁白】${正文}</正文>\n<短期记忆>无</短期记忆>\n<命令>\n</命令>`
+        }
+    }]
+});
+
+describe('流式意外终止检测与非流式降级', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('SSE 流结束时会通过 onStreamEnd 上报是否收到 [DONE]', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(构建SSE流式响应([
+            '{"choices":[{"delta":{"content":"完整内容"}}]}'
+        ]));
+        const endInfos: 通用流式结束信息[] = [];
+
+        const result = await 请求模型文本(baseConfig, [{ role: 'user', content: 'ping' }], {
+            temperature: 0.7,
+            streamOptions: { stream: true, onDelta: () => {}, onStreamEnd: (info) => endInfos.push(info) }
+        });
+
+        expect(result).toBe('完整内容');
+        expect(endInfos).toHaveLength(1);
+        expect(endInfos[0].sawDone).toBe(true);
+    });
+
+    it('连接被上游提前关闭（无 [DONE]）时 onStreamEnd 上报 sawDone=false', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(构建SSE流式响应([
+            '{"choices":[{"delta":{"content":"说到一半"}}]}'
+        ], { 发送DONE信号: false }));
+        const endInfos: 通用流式结束信息[] = [];
+
+        const result = await 请求模型文本(baseConfig, [{ role: 'user', content: 'ping' }], {
+            temperature: 0.7,
+            streamOptions: { stream: true, onDelta: () => {}, onStreamEnd: (info) => endInfos.push(info) }
+        });
+
+        expect(result).toBe('说到一半');
+        expect(endInfos).toHaveLength(1);
+        expect(endInfos[0].sawDone).toBe(false);
+        expect(endInfos[0].accumulatedLength).toBeGreaterThan(0);
+    });
+
+    it('流式被掐断且响应截断无法解析时，错误打上“流式意外终止”标记并跳过截断稿修复', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(构建SSE流式响应([
+            '{"choices":[{"delta":{"content":"<正文>\\n【旁白】她被骂作娼"}}]}'
+        ], { 发送DONE信号: false }));
+
+        const caught = await generateStoryResponse(
+            '',
+            '',
+            '',
+            baseConfig,
+            undefined,
+            { stream: true, onDelta: () => {} },
+            '',
+            {
+                orderedMessages: [{ role: 'user', content: '继续' }],
+                enableTagRepair: false,
+                validateTagCompleteness: true
+            }
+        ).then(
+            () => null,
+            (error: any) => error
+        );
+
+        expect(caught).toBeTruthy();
+        expect(caught?.流式意外终止).toBe(true);
+        expect(是否流式意外终止错误(caught)).toBe(true);
+    });
+
+    it('finish_reason=content_filter 时即使收到 [DONE] 也标记为流式意外终止', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(构建SSE流式响应([
+            '{"choices":[{"delta":{"content":"<正文>\\n【旁白】话到一半"}}]}',
+            '{"choices":[{"delta":{},"finish_reason":"content_filter"}]}'
+        ]));
+
+        const caught = await generateStoryResponse(
+            '',
+            '',
+            '',
+            baseConfig,
+            undefined,
+            { stream: true, onDelta: () => {} },
+            '',
+            {
+                orderedMessages: [{ role: 'user', content: '继续' }],
+                enableTagRepair: false,
+                validateTagCompleteness: true
+            }
+        ).then(
+            () => null,
+            (error: any) => error
+        );
+
+        expect(caught).toBeTruthy();
+        expect(caught?.流式意外终止).toBe(true);
+    });
+
+    it('未收到 [DONE] 但响应完整可解析时正常接受，不误伤省略 DONE 信号的供应商', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(构建SSE流式响应([
+            完整协议帧('完整故事。')
+        ], { 发送DONE信号: false }));
+
+        const result = await generateStoryResponse(
+            '',
+            '',
+            '',
+            baseConfig,
+            undefined,
+            { stream: true, onDelta: () => {} },
+            '',
+            {
+                orderedMessages: [{ role: 'user', content: '继续' }],
+                enableTagRepair: false
+            }
+        );
+
+        expect(result.response.logs?.some((log) => typeof log?.text === 'string' && log.text.includes('完整故事'))).toBe(true);
+    });
+
+    it('是否流式意外终止错误 覆盖各类错误形态', () => {
+        expect(是否流式意外终止错误(null)).toBe(false);
+        expect(是否流式意外终止错误(undefined)).toBe(false);
+        expect(是否流式意外终止错误(new DOMException('Aborted', 'AbortError'))).toBe(false);
+        expect(是否流式意外终止错误(new Error('普通业务错误'))).toBe(false);
+
+        expect(是否流式意外终止错误(Object.assign(new Error('解析失败'), { 流式意外终止: true }))).toBe(true);
+        expect(是否流式意外终止错误(new Error('unexpected end of stream on com.android.okhttp.Address@4ea9fa8e'))).toBe(true);
+        expect(是否流式意外终止错误(new Error('模型流式连接中途断开，通常是网络波动、代理断流或上游模型服务提前关闭连接导致'))).toBe(true);
+
+        const idleTimeout = new Error('主剧情乾坤推演流式输出空闲超时（120 秒无新增量）');
+        idleTimeout.name = 'TimeoutError';
+        expect(是否流式意外终止错误(idleTimeout)).toBe(true);
+
+        const firstResponseTimeout = new Error('主剧情乾坤推演等待首次响应超时（60 秒）');
+        firstResponseTimeout.name = 'TimeoutError';
+        expect(是否流式意外终止错误(firstResponseTimeout)).toBe(false);
+    });
+
+    it('降级提示向玩家说明已自动切换非流式', () => {
+        expect(流式意外终止降级提示).toContain('非流式');
+        expect(流式意外终止降级提示).toContain('内容审核');
+    });
+
+    it('第一次流式请求意外终止后，第二次重试明确改用非流式', async () => {
+        const requestModes: Array<{ stream: true } | undefined> = [];
+        let fallbackToNonStreaming = false;
+        let lastError: any = null;
+
+        for (let attempt = 1; attempt <= 2; attempt += 1) {
+            const strategy = 判定主剧情重试流式策略({
+                isStreaming: true,
+                fallbackToNonStreaming,
+                lastError
+            });
+            fallbackToNonStreaming = strategy.fallbackToNonStreaming;
+            requestModes.push(strategy.useStreaming ? { stream: true } : undefined);
+
+            if (attempt === 1) {
+                lastError = Object.assign(new Error('上游连接提前关闭'), { 流式意外终止: true });
+                continue;
+            }
+        }
+
+        expect(requestModes).toEqual([{ stream: true }, undefined]);
+        expect(fallbackToNonStreaming).toBe(true);
+    });
+});

--- a/components/ui/ModalErrorBoundary.tsx
+++ b/components/ui/ModalErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { isDynamicImportFetchError } from '../../utils/lazyImportWithReload';
+
+export class ModalErrorBoundary extends React.Component<
+    { children: React.ReactNode; title: string; onClose?: () => void },
+    { error: Error | null }
+> {
+    state: { error: Error | null } = { error: null };
+
+    static getDerivedStateFromError(error: Error) {
+        return { error };
+    }
+
+    componentDidCatch(error: Error) {
+        console.error('Modal render failed:', error);
+    }
+
+    render() {
+        if (!this.state.error) {
+            return this.props.children;
+        }
+
+        const isLazyImportError = isDynamicImportFetchError(this.state.error);
+        return (
+            <div className="fixed inset-0 z-[280] flex items-center justify-center bg-black/88 px-5 py-8">
+                <div className="w-full max-w-md rounded-2xl border border-red-500/45 bg-[#120909] p-5 text-red-100 shadow-[0_20px_60px_rgba(0,0,0,0.7)]">
+                    <div className="text-base font-semibold tracking-[0.12em] text-red-200">{this.props.title}</div>
+                    <div className="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-red-100/90">
+                        {this.state.error.message || '界面渲染失败'}
+                    </div>
+                    <div className="mt-4 text-xs leading-5 text-red-200/70">
+                        {isLazyImportError
+                            ? '检测到页面资源已经更新，但当前页面还停留在旧版本。点击下面按钮刷新后，通常就能直接恢复。'
+                            : '这次错误已写入运行日志。可打开"设置 → 运行日志"查看详情、复制诊断或点击"上报日志"提交给维护人员。'}
+                    </div>
+                    {isLazyImportError && (
+                        <button
+                            type="button"
+                            onClick={() => window.location.reload()}
+                            className="mt-5 inline-flex h-10 items-center justify-center rounded-lg border border-wuxia-gold/35 bg-wuxia-gold/10 px-4 text-sm text-wuxia-gold"
+                        >
+                            刷新重试
+                        </button>
+                    )}
+                    {this.props.onClose && (
+                        <button
+                            type="button"
+                            onClick={this.props.onClose}
+                            className="mt-5 inline-flex h-10 items-center justify-center rounded-lg border border-red-300/40 bg-red-950/40 px-4 text-sm text-red-50"
+                        >
+                            关闭
+                        </button>
+                    )}
+                </div>
+            </div>
+        );
+    }
+}
+

--- a/docs/superpowers/plans/2026-07-31-workbuddy-feedback-v1.0.634.md
+++ b/docs/superpowers/plans/2026-07-31-workbuddy-feedback-v1.0.634.md
@@ -1,0 +1,212 @@
+# WorkBuddy Feedback v1.0.634 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复玩家反馈的流式输出中断、酒馆预设切换后严格旁白/对白格式不再生效，以及旧页面动态模块失效导致整个应用被根错误边界接管的问题，并发布包含真实 APK 更新的 v1.0.634。
+
+**Architecture:** 请求层在 SSE 正常结束、提前关闭和 `content_filter` 之间建立明确的结束信号，主剧情重试层仅对意外终止改用非流式。酒馆组包层把“严格旁白/对白格式”视为玩家显式硬约束，在外部预设没有注入项目格式时补一条最终格式消息。设置弹窗使用局部错误边界承接旧 chunk 加载失败，保留主游戏界面并提供关闭或刷新入口。
+
+**Tech Stack:** React 19、TypeScript、Vite、Vitest、Capacitor Android、Cloudflare Workers、GitHub Actions。
+
+---
+
+### Task 1: 接续并验证流式意外终止降级
+
+**Files:**
+- Modify: `services/ai/chatCompletionClient.ts`
+- Modify: `services/ai/storyTasks.ts`
+- Modify: `hooks/useGame/sendWorkflow.ts`
+- Test: `__tests__/streamPrematureEndFallback.test.ts`
+
+- [ ] **Step 1: 将 WorkBuddy 中未提交的三个源码文件和回归测试复制到隔离工作树**
+
+保留现有 `onStreamEnd({ sawDone, finishReason, accumulatedLength })`、`流式意外终止` 标记与外层非流式降级逻辑，不重写玩家已有改动。
+
+- [ ] **Step 2: 运行现有回归测试**
+
+Run: `npm test -- --run __tests__/streamPrematureEndFallback.test.ts`
+
+Expected: 7 tests PASS；无 `[DONE]` 且截断的响应被标记，完整响应即使供应商省略 `[DONE]` 仍可接受。
+
+- [ ] **Step 3: 增加真实重试模式断言**
+
+在测试中记录 `generateStoryResponse` 两次调用的 `streamOptions`：第一次为 `{ stream: true }`，第一次抛出带 `流式意外终止` 标记的错误后，第二次必须为 `undefined`。
+
+- [ ] **Step 4: 运行新增测试并确认能约束降级行为**
+
+Run: `npm test -- --run __tests__/streamPrematureEndFallback.test.ts`
+
+Expected: PASS，且第二次请求明确为非流式。
+
+### Task 2: 恢复酒馆预设下的严格旁白/对白格式
+
+**Files:**
+- Modify: `hooks/useGame/mainStoryRequest.ts`
+- Modify: `__tests__/storyLengthValidation.test.ts`
+- Modify: `__tests__/tavernPresetTakeover.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在酒馆预设不含 `{{格式}}`/`{{format}}` 占位符时：
+
+```ts
+expect(result.messageEntries).toContainEqual(expect.objectContaining({
+  id: 'tavern_format_requirement',
+  role: 'system',
+  content: expect.stringContaining('【旁白】')
+}));
+```
+
+并验证 `启用严格正文对白格式: false` 时仍保持外部预设完全接管，不注入该消息；预设已使用格式占位符时不重复注入。
+
+- [ ] **Step 2: 运行测试确认 RED**
+
+Run: `npm test -- --run __tests__/storyLengthValidation.test.ts __tests__/tavernPresetTakeover.test.ts`
+
+Expected: FAIL，缺少 `tavern_format_requirement`。
+
+- [ ] **Step 3: 写最小实现**
+
+在 `构建主剧情请求参数` 的酒馆分支完成预设消息组包后执行：
+
+```ts
+const strictFormatPrompt = runtimeGameConfig.启用严格正文对白格式 !== false
+  ? params.builtContext.contextPieces.格式提示词.trim()
+  : '';
+const formatAlreadyInjected = strictFormatPrompt
+  && tavernMessages.some((message) => message.content.includes(strictFormatPrompt));
+if (strictFormatPrompt && !formatAlreadyInjected) {
+  messageEntries.push({
+    id: 'tavern_format_requirement',
+    title: '酒馆严格旁白/对白格式',
+    category: '系统',
+    role: 'system',
+    content: strictFormatPrompt
+  });
+}
+```
+
+- [ ] **Step 4: 运行测试确认 GREEN**
+
+Run: `npm test -- --run __tests__/storyLengthValidation.test.ts __tests__/tavernPresetTakeover.test.ts`
+
+Expected: PASS；严格开关开启时补格式，关闭时不补，已有占位符时不重复。
+
+### Task 3: 防止 settings-world 旧 chunk 错误击穿根界面
+
+**Files:**
+- Modify: `App.tsx`
+- Test: `__tests__/settingsLazyImportBoundary.test.ts`
+
+- [ ] **Step 1: 写失败的结构回归测试**
+
+读取 `App.tsx` 的设置弹窗区块，断言其结构为：
+
+```tsx
+<ModalErrorBoundary title="设置打开失败" onClose={closeSettings}>
+  <懒加载边界>...</懒加载边界>
+</ModalErrorBoundary>
+```
+
+并断言 `SettingsModal` 与 `MobileSettingsModal` 均位于该局部边界内。
+
+- [ ] **Step 2: 运行测试确认 RED**
+
+Run: `npm test -- --run __tests__/settingsLazyImportBoundary.test.ts`
+
+Expected: FAIL，当前设置弹窗只有 `Suspense`，错误会冒泡到根 `ErrorBoundary`。
+
+- [ ] **Step 3: 写最小实现**
+
+在 `state.showSettings` 区块内，用现有 `ModalErrorBoundary` 包住设置懒加载树并传入 `onClose={closeSettings}`，保留现有 `DynamicImportDeferredReloadError` 的“刷新重试”按钮。
+
+- [ ] **Step 4: 运行测试确认 GREEN**
+
+Run: `npm test -- --run __tests__/settingsLazyImportBoundary.test.ts __tests__/lazyImportWithReload.test.ts`
+
+Expected: PASS；旧 chunk 错误只关闭/刷新设置弹窗，不再让整个游戏进入根错误页。
+
+### Task 4: 完整验证与本地 UI 检查
+
+**Files:**
+- Verify: changed source and tests
+
+- [ ] **Step 1: 运行针对性回归**
+
+Run: `npm test -- --run __tests__/streamPrematureEndFallback.test.ts __tests__/storyLengthValidation.test.ts __tests__/tavernPresetTakeover.test.ts __tests__/settingsLazyImportBoundary.test.ts __tests__/lazyImportWithReload.test.ts __tests__/storyResponseParser.test.ts`
+
+- [ ] **Step 2: 运行全量测试**
+
+Run: `npm test -- --run`
+
+Expected: 所有本地确定性测试通过；若仅外部 AI E2E 因网络/凭据失败，记录精确用例和证据。
+
+- [ ] **Step 3: 构建网页**
+
+Run: `npm run build`
+
+Expected: exit 0，并记录 `dist/index.html` 引用的 `assets/index-*.js`。
+
+- [ ] **Step 4: 本地浏览器验证**
+
+使用现有存档进入真实游戏，在 `day` 主题打开设置：切换酒馆预设与“严格旁白/对白格式”开关，确认状态可恢复、文字可读；同时确认设置弹窗能关闭且不遮挡主界面。
+
+### Task 5: PR、CodeRabbit 与 CI
+
+**Files:**
+- Commit all source/test/plan files for the fix branch
+
+- [ ] **Step 1: 提交并推送 `codex/workbuddy-feedback-v634`**
+
+Run: `git add <scoped files> && git commit -m "fix: 修复流式中断与设置回归" && git push -u origin codex/workbuddy-feedback-v634`
+
+- [ ] **Step 2: 创建 PR 到 `main`**
+
+PR 描述列出三项修复、测试命令和发布计划。
+
+- [ ] **Step 3: 等待并处理 CodeRabbit 审查**
+
+逐条核实评论；合理意见先补失败测试再修改；回复并确认评论闭环。
+
+- [ ] **Step 4: 确认 PR CI 成功并合并**
+
+合并后在主仓库 `main` 拉取最新提交并重新跑针对性测试与构建。
+
+### Task 6: 发布 v1.0.634（含 APK）
+
+**Files:**
+- Modify: `release.config.json`
+- Modify via sync: `package.json`, `android/app/build.gradle`, `data/releaseInfo.ts`, `public/release-info.json`
+- Build: `android/app/build/outputs/apk/release/app-release.apk`
+
+- [ ] **Step 1: 在 `main` 将版本从 1.0.633/633 升到 1.0.634/634**
+
+发布说明只包含玩家可见内容：流式中断自动恢复、严格旁白/对白格式恢复、设置模块更新后不再击穿整个界面。
+
+- [ ] **Step 2: 刷新真实发布时间并运行 `npm run release:sync`**
+
+`releasePublishedAt` 使用发布前当前北京时间，再执行同步。
+
+- [ ] **Step 3: 创建并推送发布备份提交**
+
+提交必须在 `main`，并在构建、上传、部署前推送到 `origin/main`。
+
+- [ ] **Step 4: 构建网页与 APK**
+
+Run: `npm run build`, `npm run apk:sync`, `cd android; .\\gradlew.bat assembleRelease`
+
+- [ ] **Step 5: 验证 APK**
+
+使用 `apksigner verify --verbose --print-certs`，确认版本 634、签名方案有效、证书 SHA-256 为 `0c638692591300750ccc17cb828b5223bb9a5ef333095714377a6cd5adcbe48c`，并记录 APK 大小与 SHA-256。
+
+- [ ] **Step 6: 上传并发布**
+
+分别执行 GitHub Release、OneDrive/OpenList APK 上传、Cloudflare 网站部署与远程 KV manifest 写入；所有外部命令使用显式超时。
+
+- [ ] **Step 7: 全发布面验证**
+
+双域 `/release-info.json` 必须为 1.0.634/634 且时间一致；双域 `index.html` 的 hashed bundle 与本地 `dist` 一致；`/api/apk/latest.json` 的版本、大小、SHA 与 APK 一致；下载公开 APK 后再次验证大小、SHA、版本和签名。
+
+- [ ] **Step 8: 检查目标仓库 CI**
+
+明确检查 `ypq123456789/MoRanJiangHu` 上发布提交对应的最新 `CI` run；失败则读取日志并修复或报告阻塞。

--- a/hooks/useGame/mainStoryRequest.ts
+++ b/hooks/useGame/mainStoryRequest.ts
@@ -187,8 +187,8 @@ export const 构建主剧情请求参数 = (
     const messageEntries: 主剧情消息条目[] = [];
 
 	    if (tavernPresetModeEnabled) {
-	        // 酒馆模式：外部预设主导叙事提示词；玩家设置的最低字数作为硬约束例外保留。
-	        // 其他项目风格、格式和免责声明仍不混入。
+	        // 酒馆模式：外部预设主导叙事提示词；玩家显式开启的最低字数与严格旁白/对白格式
+	        // 作为硬约束例外保留。其他项目风格和免责声明仍不混入。
 	        const tavernMessages = 构建酒馆预设消息链({
 	            config: runtimeGameConfig,
 	            context: params.builtContext,
@@ -217,6 +217,20 @@ export const 构建主剧情请求参数 = (
                 content: trimmed
             });
         });
+        const strictFormatPrompt = runtimeGameConfig.启用严格正文对白格式 !== false
+            ? params.builtContext.contextPieces.格式提示词.trim()
+            : '';
+        const formatAlreadyInjected = Boolean(strictFormatPrompt)
+            && tavernMessages.some((message) => (message?.content || '').includes(strictFormatPrompt));
+        if (strictFormatPrompt && !formatAlreadyInjected) {
+            messageEntries.push({
+                id: 'tavern_format_requirement',
+                title: '酒馆严格旁白/对白格式',
+                category: '系统',
+                role: 'system',
+                content: strictFormatPrompt
+            });
+        }
         if (lengthRequirementPrompt.trim()) {
             messageEntries.push({
                 id: 'tavern_length_requirement',

--- a/hooks/useGame/sendWorkflow.ts
+++ b/hooks/useGame/sendWorkflow.ts
@@ -1,4 +1,5 @@
 import * as textAIService from '../../services/ai/text';
+import { 是否流式连接中断错误消息 } from '../../services/ai/chatCompletionClient';
 import { recordAiParseFailureDiagnostic } from '../../services/diagnosticContext';
 import { recordDiagnosticLog } from '../../services/diagnosticLog';
 import type { GameResponse, OpeningConfig, 聊天记录结构, 记忆系统结构, 角色数据结构, 剧情系统结构, 剧情规划结构, 女主剧情规划结构, 同人剧情规划结构, 同人女主剧情规划结构, 世界书结构, 内置提示词条目结构, 叙事状态结构, 叙事平静值配置结构 } from '../../types';
@@ -230,6 +231,37 @@ export const 提取自动重试原因文本 = (error: any): string => {
     }
     return '请求失败，正在重试';
 };
+
+/**
+ * 判断错误是否属于「流式输出被上游意外终止」：
+ * 典型场景是正文出现特定词汇（如“娼妇”）触发上游内容审核直接掐断流式通道，
+ * 也可能由代理断流或流式空闲超时引起。命中后外层重试应降级为非流式请求。
+ */
+export const 是否流式意外终止错误 = (error: any): boolean => {
+    if (!error || error?.name === 'AbortError') return false;
+    if (error?.流式意外终止 === true) return true;
+    const message = String(error?.message || '');
+    const detail = String(error?.detail || '');
+    if (是否流式连接中断错误消息(message) || 是否流式连接中断错误消息(detail)) return true;
+    if (message.includes('模型流式连接中途断开') || detail.includes('模型流式连接中途断开')) return true;
+    if (String(error?.name || '') === 'TimeoutError' && message.includes('流式输出空闲超时')) return true;
+    return false;
+};
+
+export const 判定主剧情重试流式策略 = (params: {
+    isStreaming: boolean;
+    fallbackToNonStreaming: boolean;
+    lastError?: any;
+}): { useStreaming: boolean; fallbackToNonStreaming: boolean } => {
+    const fallbackToNonStreaming = params.fallbackToNonStreaming
+        || (params.isStreaming && Boolean(params.lastError) && 是否流式意外终止错误(params.lastError));
+    return {
+        useStreaming: params.isStreaming && !fallbackToNonStreaming,
+        fallbackToNonStreaming
+    };
+};
+
+export const 流式意外终止降级提示 = '流式输出被上游中断（常见于触发上游内容审核或代理断流），已自动切换为非流式重新生成';
 
 export const 校验响应未命中女性姓名黑名单 = (
     response: GameResponse,
@@ -1712,6 +1744,9 @@ export const 执行主剧情发送工作流 = async (
     let 后台队列已启动 = false;
     let streamMarker = 0;
     let latestStreamDraftText = '';
+    // 流式输出被上游意外终止（如内容审核掐断、代理断流、流式空闲超时）后置为 true，
+    // 后续自动重试改用非流式请求，避免同一内容在流式通道上反复被掐断。
+    let 流式意外终止需降级非流式 = false;
 
     try {
         const recallContextActiveForMain = recallFeatureEnabled && Boolean(recallTag);
@@ -1811,20 +1846,31 @@ export const 执行主剧情发送工作流 = async (
         const aiResult = await deps.执行带自动重试的生成请求<textAIService.StoryResponseResult>({
             enabled: deps.游戏设置启用自动重试(runtimeGameConfig),
             onRetry: (attempt, maxAttempts, reason) => {
+                const 重试原因 = 流式意外终止需降级非流式 && isStreaming
+                    ? 流式意外终止降级提示
+                    : reason;
                 recordDiagnosticLog('warn', ['主剧情重试', {
                     attempt,
                     maxAttempts,
-                    reason: typeof reason === 'string' ? reason : reason?.message || '',
-                    errorName: reason?.name || '',
-                    streaming: isStreaming
+                    reason: 重试原因,
+                    streaming: isStreaming,
+                    降级非流式: 流式意外终止需降级非流式
                 }]);
                 if (isStreaming) {
-                    deps.设置历史记录(prev => deps.更新流式草稿为自动重试提示(prev, attempt, maxAttempts, reason));
+                    deps.设置历史记录(prev => deps.更新流式草稿为自动重试提示(prev, attempt, maxAttempts, 重试原因));
                 }
             },
             action: async (attempt, lastError) => {
                 const lastErrorIsBodyLengthShortage = 是否正文字数不足错误(lastError);
                 const lastErrorIsBodyQualityIssue = 是否正文质量审查错误(lastError);
+                // 上一次尝试若是流式被上游意外终止（含 storyTasks 标记的“流式意外终止”），本次起降级为非流式
+                const streamRetryStrategy = 判定主剧情重试流式策略({
+                    isStreaming,
+                    fallbackToNonStreaming: 流式意外终止需降级非流式,
+                    lastError
+                });
+                流式意外终止需降级非流式 = streamRetryStrategy.fallbackToNonStreaming;
+                const 本次使用流式 = streamRetryStrategy.useStreaming;
                 const protocolRetryPrompt = (
                     attempt > 1
                     && !lastErrorIsBodyLengthShortage
@@ -1868,7 +1914,7 @@ export const 执行主剧情发送工作流 = async (
                         '',
                         activeApi,
                         signal,
-                        isStreaming
+                        本次使用流式
                             ? {
                                 stream: true,
                                 onDelta: (_delta, accumulated) => {
@@ -1920,20 +1966,35 @@ export const 执行主剧情发送工作流 = async (
                         }
                     );
 
-                const storyResult = !isStreaming
-                    ? await requestStory(controller.signal)
-                    : await 执行主剧情流式请求带空闲超时(
-                        controller.signal,
-                        (signal, markStreamActivity) => requestStory(signal, markStreamActivity),
-                        () => 尝试解析完整主剧情流式草稿(latestStreamDraftText, {
-                            validateTagCompleteness: runtimeGameConfig.启用标签检测完整性 === true,
-                            enableTagRepair: runtimeGameConfig.启用标签修复 !== false,
-                            requireActionOptionsTag: runtimeGameConfig.启用行动选项 !== false,
-                            validateDialogueFormat: runtimeGameConfig.启用严格正文对白格式 !== false,
-                            knownSpeakers: knownDialogueSpeakers
-                        }),
-                        获取游玩请求超时毫秒(runtimeGameConfig.游玩请求超时设置)
-                    );
+                let storyResult: textAIService.StoryResponseResult;
+                try {
+                    storyResult = !本次使用流式
+                        ? await requestStory(controller.signal)
+                        : await 执行主剧情流式请求带空闲超时(
+                            controller.signal,
+                            (signal, markStreamActivity) => requestStory(signal, markStreamActivity),
+                            () => 尝试解析完整主剧情流式草稿(latestStreamDraftText, {
+                                validateTagCompleteness: runtimeGameConfig.启用标签检测完整性 === true,
+                                enableTagRepair: runtimeGameConfig.启用标签修复 !== false,
+                                requireActionOptionsTag: runtimeGameConfig.启用行动选项 !== false,
+                                validateDialogueFormat: runtimeGameConfig.启用严格正文对白格式 !== false,
+                                knownSpeakers: knownDialogueSpeakers
+                            }),
+                            获取游玩请求超时毫秒(runtimeGameConfig.游玩请求超时设置)
+                        );
+                } catch (streamError: any) {
+                    // 流式被上游意外终止时立即标记，让 onRetry 与下一次尝试切换到非流式
+                    if (本次使用流式 && !流式意外终止需降级非流式 && 是否流式意外终止错误(streamError)) {
+                        流式意外终止需降级非流式 = true;
+                        recordDiagnosticLog('warn', ['主剧情流式意外终止-降级非流式', {
+                            attempt,
+                            message: String(streamError?.message || ''),
+                            errorName: String(streamError?.name || ''),
+                            已被服务层标记: streamError?.流式意外终止 === true
+                        }]);
+                    }
+                    throw streamError;
+                }
                 const rawStoryText = deps.获取原始AI消息(storyResult.rawText);
                 const reviewedResponse = runtimeGameConfig.启用正文词汇审查 === false
                     ? storyResult.response

--- a/services/ai/chatCompletionClient.ts
+++ b/services/ai/chatCompletionClient.ts
@@ -15,9 +15,19 @@ export type 通用消息 = {
 
 export type 响应格式类型 = 'json_object';
 
+export type 通用流式结束信息 = {
+    /** 是否收到了上游的 [DONE] 结束信号；false 表示连接被上游提前关闭（常见于内容审核拦截或代理断流）。 */
+    sawDone: boolean;
+    /** SSE 最后一帧的 finish_reason（如有）；'content_filter' 表示明确命中上游内容审核。 */
+    finishReason?: string;
+    /** 流结束时的累积文本长度。 */
+    accumulatedLength: number;
+};
+
 export type 通用流式选项 = {
     stream?: boolean;
     onDelta?: (delta: string, accumulated: string) => void;
+    onStreamEnd?: (info: 通用流式结束信息) => void;
 } | undefined;
 
 export type 模型请求附加选项 = {
@@ -898,13 +908,15 @@ export const 读取失败详情文本 = async (response: Response, maxLen = 600)
 
 const 创建SSE文本处理器 = (
     extractDelta: 增量提取器,
-    onDelta?: (delta: string, accumulated: string) => void
+    onDelta?: (delta: string, accumulated: string) => void,
+    onStreamEnd?: (info: 通用流式结束信息) => void
 ) => {
     let rawBuffer = '';
     let accumulated = '';
     let sawSseFrame = false;
     let doneSignal = false;
     let pendingJsonPayload = '';
+    let lastFinishReason = '';
 
     const emitDelta = (delta: string) => {
         if (!delta) return;
@@ -918,6 +930,10 @@ const 创建SSE文本处理器 = (
 
         try {
             const json = JSON.parse(payload);
+            const finishReason = json?.choices?.[0]?.finish_reason;
+            if (typeof finishReason === 'string' && finishReason.trim()) {
+                lastFinishReason = finishReason.trim();
+            }
             emitDelta(extractDelta(json));
             return true;
         } catch {
@@ -1003,6 +1019,12 @@ const 创建SSE文本处理器 = (
             throw new Error('Stream response did not contain text/event-stream data frames');
         }
 
+        onStreamEnd?.({
+            sawDone: doneSignal,
+            finishReason: lastFinishReason || undefined,
+            accumulatedLength: accumulated.length
+        });
+
         return accumulated.trim();
     };
 
@@ -1017,13 +1039,14 @@ const 解析SSE文本 = async (
     response: Response,
     extractDelta: 增量提取器,
     onDelta?: (delta: string, accumulated: string) => void,
-    emptyBodyError = 'Stream body is empty'
+    emptyBodyError = 'Stream body is empty',
+    onStreamEnd?: (info: 通用流式结束信息) => void
 ): Promise<string> => {
     if (!response.body) throw new Error(emptyBodyError);
 
     const reader = response.body.getReader();
     const decoder = new TextDecoder('utf-8');
-    const processor = 创建SSE文本处理器(extractDelta, onDelta);
+    const processor = 创建SSE文本处理器(extractDelta, onDelta, onStreamEnd);
     const fetchStats = {
         totalChunks: 0,
         totalBytes: 0,
@@ -1097,10 +1120,11 @@ const 解析SSE文本原生 = async (
     body: string,
     signal: AbortSignal | undefined,
     extractDelta: 增量提取器,
-    onDelta?: (delta: string, accumulated: string) => void
+    onDelta?: (delta: string, accumulated: string) => void,
+    onStreamEnd?: (info: 通用流式结束信息) => void
 ): Promise<string> => {
     const requestId = 生成原生流请求ID();
-    const processor = 创建SSE文本处理器(extractDelta, onDelta);
+    const processor = 创建SSE文本处理器(extractDelta, onDelta, onStreamEnd);
     let listenerHandle: PluginListenerHandle | null = null;
     let settled = false;
 
@@ -1203,10 +1227,11 @@ const 解析SSE文本XHR = (
     body: string,
     signal: AbortSignal | undefined,
     extractDelta: 增量提取器,
-    onDelta?: (delta: string, accumulated: string) => void
+    onDelta?: (delta: string, accumulated: string) => void,
+    onStreamEnd?: (info: 通用流式结束信息) => void
 ): Promise<string> => new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    const processor = 创建SSE文本处理器(extractDelta, onDelta);
+    const processor = 创建SSE文本处理器(extractDelta, onDelta, onStreamEnd);
     let consumedLength = 0;
     let settled = false;
     const streamStats = {
@@ -1647,7 +1672,8 @@ const 请求OpenAI家族文本 = async (
                     requestBody,
                     signal,
                     创建OpenAI流增量提取器({ includeReasoning: requestOptions?.includeReasoning }),
-                    streamOptions?.onDelta
+                    streamOptions?.onDelta,
+                    streamOptions?.onStreamEnd
                 );
             } catch (error) {
                 console.warn('[native.stream.failed]', {
@@ -1686,7 +1712,8 @@ const 请求OpenAI家族文本 = async (
                     requestBody,
                     signal,
                     创建OpenAI流增量提取器({ includeReasoning: requestOptions?.includeReasoning }),
-                    streamOptions?.onDelta
+                    streamOptions?.onDelta,
+                    streamOptions?.onStreamEnd
                 );
             } catch (error) {
                 写入流式诊断日志('xhr stream failed', {
@@ -1754,7 +1781,7 @@ const 请求OpenAI家族文本 = async (
                 supplier: apiConfig.供应商,
                 contentType
             });
-            return await 解析SSE文本(response, 创建OpenAI流增量提取器({ includeReasoning: requestOptions?.includeReasoning }), streamOptions?.onDelta, 'Stream body is empty');
+            return await 解析SSE文本(response, 创建OpenAI流增量提取器({ includeReasoning: requestOptions?.includeReasoning }), streamOptions?.onDelta, 'Stream body is empty', streamOptions?.onStreamEnd);
         } catch (error) {
             if (!downgradedFromStream && 错误疑似不支持流式(error)) {
                 useStream = false;

--- a/services/ai/storyTasks.ts
+++ b/services/ai/storyTasks.ts
@@ -40,12 +40,14 @@ import { 世界书本体槽位 } from '../../utils/worldbook';
 import { 获取内置提示词槽位内容 } from '../../utils/builtinPrompts';
 import {
     type 通用消息,
+    type 通用流式结束信息,
     规范化文本补全消息链,
     请求模型文本,
     替换COT伪装身份占位
 } from './chatCompletionClient';
 import {
     parseStoryRawText,
+    StoryResponseParseError,
     type StoryParseOptions,
     提取首个标签内容,
     提取首尾思考区段,
@@ -204,6 +206,7 @@ export interface NovelDecompositionAnalysisResult {
 export interface StoryStreamOptions {
     stream?: boolean;
     onDelta?: (delta: string, accumulated: string) => void;
+    onStreamEnd?: (info: 通用流式结束信息) => void;
 }
 
 export interface StoryRequestOptions {
@@ -2088,6 +2091,53 @@ export const generateStoryResponse = async (
 ): Promise<StoryResponseResult> => {
     if (!apiConfig.apiKey) throw new Error('Missing API Key');
 
+    // 流式输出被上游提前关闭（常见于内容审核拦截，例如正文出现“娼妇”等词汇时上游直接掐断流）时，
+    // 记录结束信息并给错误打上“流式意外终止”标记，供外层重试逻辑自动降级为非流式请求，
+    // 避免同一内容在流式通道上反复被掐断导致本回合彻底失败。
+    let 流式结束信息: 通用流式结束信息 | null = null;
+    const 带结束回调的流式选项: StoryStreamOptions | undefined = streamOptions?.stream === true
+        ? {
+            ...streamOptions,
+            onStreamEnd: (info) => {
+                流式结束信息 = info;
+                streamOptions.onStreamEnd?.(info);
+            }
+        }
+        : streamOptions;
+    const 流式疑似被上游中断 = (): boolean => Boolean(
+        streamOptions?.stream === true
+        && 流式结束信息
+        && (流式结束信息.sawDone === false || 流式结束信息.finishReason === 'content_filter')
+    );
+    const 解析主剧情故事响应 = (rawText: string): StoryResponseResult => {
+        const result = 解析故事响应(rawText, requestOptions);
+        if (!流式疑似被上游中断()) return result;
+        if (流式结束信息?.finishReason === 'content_filter') {
+            const detail = '流式输出被上游内容审核拦截（finish_reason=content_filter），响应不完整，请改用非流式重新生成';
+            const error = new StoryResponseParseError(detail, rawText, detail);
+            (error as any).流式意外终止 = true;
+            throw error;
+        }
+        if (流式结束信息?.sawDone === false) {
+            console.warn('[主剧情] 流式连接未收到 [DONE] 即结束，但响应解析成功，按完整响应接受', {
+                accumulatedLength: 流式结束信息.accumulatedLength
+            });
+        }
+        return result;
+    };
+    const 流式意外终止则抛出 = (error: any): void => {
+        if (!流式疑似被上游中断()) return;
+        if (error && typeof error === 'object') {
+            error.流式意外终止 = true;
+        }
+        console.warn('[主剧情] 流式输出疑似被上游中断，跳过截断稿修复，交给外层降级非流式重试', {
+            sawDone: 流式结束信息?.sawDone,
+            finishReason: 流式结束信息?.finishReason,
+            accumulatedLength: 流式结束信息?.accumulatedLength
+        });
+        throw error;
+    };
+
     const orderedMessagesRaw = Array.isArray(requestOptions?.orderedMessages)
         ? requestOptions.orderedMessages
             .map((item) => {
@@ -2139,7 +2189,7 @@ export const generateStoryResponse = async (
         const rawText = await 请求模型文本(apiConfig, messagesWithRuntimeRequirements, {
             temperature: 0.7,
             signal,
-            streamOptions,
+            streamOptions: 带结束回调的流式选项,
             errorDetailLimit: requestOptions?.errorDetailLimit,
             includeReasoning: requestOptions?.includeReasoning,
             disableThinking: requestOptions?.disableThinking,
@@ -2147,8 +2197,9 @@ export const generateStoryResponse = async (
             prefixMode: requestOptions?.prefixMode
         });
         try {
-            return 解析故事响应(rawText, requestOptions);
+            return 解析主剧情故事响应(rawText);
         } catch (error: any) {
+            流式意外终止则抛出(error);
             if (requestOptions?.validateDialogueFormat === true && error?.name === 'StoryResponseParseError') {
                 if (是否正文对白格式错误(error)) {
                     try {
@@ -2233,7 +2284,7 @@ export const generateStoryResponse = async (
     const rawText = await 请求模型文本(apiConfig, normalizedApiMessages, {
         temperature: 0.7,
         signal,
-        streamOptions,
+        streamOptions: 带结束回调的流式选项,
         errorDetailLimit: requestOptions?.errorDetailLimit,
         includeReasoning: requestOptions?.includeReasoning,
         disableThinking: requestOptions?.disableThinking,
@@ -2242,8 +2293,9 @@ export const generateStoryResponse = async (
     });
 
     try {
-        return 解析故事响应(rawText, requestOptions);
+        return 解析主剧情故事响应(rawText);
     } catch (error: any) {
+        流式意外终止则抛出(error);
         if (requestOptions?.validateDialogueFormat === true && error?.name === 'StoryResponseParseError') {
             if (是否正文对白格式错误(error)) {
                 try {


### PR DESCRIPTION
## 修复内容

- 流式正文被上游内容审核或代理提前掐断时，识别缺失 `[DONE]` / `finish_reason=content_filter`，自动降级为非流式重试。
- 酒馆预设切换后，重新开启“严格旁白/对白格式”会恢复格式硬约束；预设已使用 `{{格式}}` 时不重复注入。
- 设置模块旧 chunk 加载失败由设置弹窗局部错误边界承接，不再击穿整个游戏界面。

## 验证

- 针对性回归：101 项通过。
- 确定性全量测试：排除外部 AI 实接口超时用例后全部通过。
- `npm run build` 成功，主入口资源：`assets/index-BBx7Hkot.js`。
- 日间模式本地 UI：设置可打开/关闭，严格格式开关可关闭后重新开启，无动态导入或根渲染错误。

## 已知验证限制

- `aiReturnedNameE2E.test.ts` 的外部 AI 实接口用例在 120 秒后超时，与本次改动无关。
- 本地 CodeRabbit CLI 安装源连接失败，等待仓库侧 PR 审查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 流式响应意外中断时，系统会自动切换为非流式请求重试，并显示相应提示。
  * 酒馆预设模式下，必要时自动补充严格的旁白与对白格式要求，避免重复添加。
  * 设置弹窗加载失败时显示错误界面，并支持关闭弹窗。

* **问题修复**
  * 改善内容审核拦截、代理断流及响应截断等异常场景的处理。
  * 避免对不完整的流式响应执行错误的正文修复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->