### PR TITLE
fix: 修复小说分解工作台空数据集崩溃（reading '题材'）

### DIFF
--- a/__tests__/novelModePackCompletionNullDataset.test.tsx
+++ b/__tests__/novelModePackCompletionNullDataset.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { useNovelModePackCompletion, 解析当前小说模式包激活记录, 计算小说模式包完善界面状态 } from '../hooks/useNovelModePackCompletion';
+import type { 小说拆分数据集结构 } from '../models/novelDecomposition';
+import type { 小说模式包完善记录 } from '../models/novelModePackCompletion';
+import type { 当前可用接口结构 } from '../utils/apiConfig';
+
+vi.mock('../services/novelModePackCompletionStore', () => ({
+    删除小说模式包完善记录: vi.fn().mockResolvedValue(undefined),
+    构建小说模式包数据集指纹: vi.fn().mockResolvedValue(''),
+    读取小说模式包完善记录: vi.fn().mockResolvedValue(null),
+    保存小说模式包完善记录: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../services/novelModePackCompletionWorkflow', () => ({
+    执行小说模式包逐段完善: vi.fn()
+}));
+
+vi.mock('../services/ai/storyTasks', () => ({
+    generateNovelModePackFinalization: vi.fn(),
+    generateNovelModePackSegmentCompletion: vi.fn()
+}));
+
+vi.mock('../services/novelDecompositionWorkshopBridge', () => ({
+    清洗小说模式包累积草稿: vi.fn((draft: unknown) => draft)
+}));
+
+const 构建记录 = (overrides: Partial<小说模式包完善记录> = {}): 小说模式包完善记录 => ({
+    id: 'ds1::武侠',
+    数据集ID: 'ds1',
+    题材: '武侠',
+    数据集指纹: 'fp',
+    状态: 'paused',
+    当前阶段: 'segment',
+    总分段数: 1,
+    已完成分段数: 0,
+    下一个分段索引: 0,
+    当前草稿: {},
+    分段输入记录: [],
+    用户确认字段路径: [],
+    ...overrides
+} as unknown as 小说模式包完善记录);
+
+const 构建数据集 = (id = 'ds1'): 小说拆分数据集结构 => ({ id, 分段列表: [] } as unknown as 小说拆分数据集结构);
+
+const Inner: React.FC<{ dataset: 小说拆分数据集结构 | null }> = ({ dataset }) => {
+    const result = useNovelModePackCompletion({
+        dataset,
+        baseMode: '武侠',
+        apiConfig: null as unknown as 当前可用接口结构 | null | undefined,
+        onNotify: undefined
+    });
+    return <div>{result.record ? 'has-record' : 'no-record'}</div>;
+};
+
+describe('小说分解工作台：模式包完善记录空值防护', () => {
+    it('[回归] 未选中小说时 record 与 dataset 同为 null，不得读取 null 的 题材', () => {
+        // 历史崩溃写法：`record?.数据集ID === dataset?.id && record.题材 === baseMode`
+        // 两侧同为 undefined 时前半段成立，继续读 record.题材 会抛
+        // TypeError: Cannot read properties of null (reading '题材')。
+        expect(() => 解析当前小说模式包激活记录(true, null, null, '武侠')).not.toThrow();
+        expect(解析当前小说模式包激活记录(true, null, null, '武侠')).toBeNull();
+    });
+
+    it('[回归] 记录字段缺失且未选中小说时同样不激活', () => {
+        const 残缺记录 = 构建记录({ 数据集ID: undefined as unknown as string });
+        expect(解析当前小说模式包激活记录(true, 残缺记录, null, '武侠')).toBeNull();
+    });
+
+    it('已选中小说但尚无记录时返回 null', () => {
+        expect(解析当前小说模式包激活记录(true, null, 构建数据集(), '武侠')).toBeNull();
+    });
+
+    it('进度尚未加载完成时不激活任何记录', () => {
+        expect(解析当前小说模式包激活记录(false, 构建记录(), 构建数据集(), '武侠')).toBeNull();
+    });
+
+    it('记录归属的数据集与当前数据集不一致时不激活', () => {
+        expect(解析当前小说模式包激活记录(true, 构建记录(), 构建数据集('ds2'), '武侠')).toBeNull();
+    });
+
+    it('记录题材与当前题材不一致时不激活', () => {
+        expect(解析当前小说模式包激活记录(true, 构建记录({ 题材: '仙侠' as any }), 构建数据集(), '武侠')).toBeNull();
+    });
+
+    it('数据集与题材同时命中时返回该记录', () => {
+        const record = 构建记录();
+        expect(解析当前小说模式包激活记录(true, record, 构建数据集(), '武侠')).toBe(record);
+    });
+
+    it('未选中小说时界面状态可安全计算，提示尚未开始', () => {
+        const uiState = 计算小说模式包完善界面状态(解析当前小说模式包激活记录(true, null, null, '武侠'), false, true, true, false);
+        expect(uiState.statusText).toBe('尚未开始逐分段完善');
+        expect(uiState.primaryAction).toBe('start');
+        expect(uiState.showRestart).toBe(false);
+    });
+
+    it('工作台在未选中小说时可完成首屏渲染', () => {
+        const html = renderToStaticMarkup(<Inner dataset={null} />);
+        expect(html).toContain('no-record');
+    });
+});

--- a/e2e/novel-decomposition-workbench.pw.mjs
+++ b/e2e/novel-decomposition-workbench.pw.mjs
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+
+const TARGET_URL = process.env.E2E_BASE_URL || 'http://127.0.0.1:4173';
+
+const API_MIRROR_KEY = 'moranjianghu.apiConfig.localMirror.v1';
+const RELEASE_NOTES_SUPPRESS_KEY = 'moranjianghu.releaseNotesSuppressDate';
+
+// 崩溃特征：未选中小说时 record/dataset 同为 null，旧代码的 `record?.数据集ID === dataset?.id`
+// 会因 undefined === undefined 成立而继续读取 record.题材，抛出该 TypeError。
+const CRASH_SIGNATURE = /Cannot read properties of null \(reading '题材'\)|null is not an object.*题材/;
+
+const makeApiConfigMirror = () => ({
+    activeConfigId: null,
+    configs: [],
+    功能模型占位: {
+        小说拆分功能启用: true,
+        小说拆分独立模型开关: true,
+        小说拆分使用模型: 'e2e-novel-split-model',
+        小说拆分API地址: 'https://e2e.invalid/v1',
+        小说拆分API密钥: 'e2e-novel-split-key',
+    },
+});
+
+const collectPageErrors = (page) => {
+    const errors = [];
+    page.on('pageerror', (error) => {
+        errors.push(`pageerror: ${error?.message || String(error)}`);
+    });
+    page.on('console', (message) => {
+        if (message.type() !== 'error') return;
+        errors.push(`console: ${message.text()}`);
+    });
+    return errors;
+};
+
+const prepareLandingPage = async (page) => {
+    await page.addInitScript(
+        ({ mirrorKey, mirrorValue, suppressKey }) => {
+            localStorage.setItem(mirrorKey, JSON.stringify(mirrorValue));
+            localStorage.setItem(suppressKey, new Date().toISOString().slice(0, 10));
+        },
+        {
+            mirrorKey: API_MIRROR_KEY,
+            mirrorValue: makeApiConfigMirror(),
+            suppressKey: RELEASE_NOTES_SUPPRESS_KEY,
+        }
+    );
+};
+
+const openWorkbenchFromWorkshop = async (page) => {
+    await page.goto(`${TARGET_URL}/?open=workshop`, { waitUntil: 'networkidle' });
+
+    const workshopTitle = page.getByRole('heading', { name: '创意工坊' });
+    await expect(workshopTitle).toBeVisible({ timeout: 15000 });
+
+    const novelDecompositionEntry = page.getByRole('button', { name: /小说分解模块/ }).first();
+    await expect(novelDecompositionEntry).toBeVisible({ timeout: 10000 });
+    await novelDecompositionEntry.click({ timeout: 5000 });
+};
+
+const expectWorkbenchOpenedWithoutCrash = async (page, errors) => {
+    const failureBanner = page.getByText('小说分解工作台打开失败', { exact: false });
+    const workbenchTitle = page.getByRole('heading', { name: '小说分解工作台', exact: true });
+
+    await expect(workbenchTitle).toBeVisible({ timeout: 20000 });
+    await expect(failureBanner).toHaveCount(0);
+
+    const crashErrors = errors.filter((item) => CRASH_SIGNATURE.test(item));
+    expect(crashErrors, `不应出现空数据集崩溃：\n${crashErrors.join('\n')}`).toEqual([]);
+};
+
+test.describe('小说分解工作台空数据集回归', () => {
+    test('未选中小说时打开工作台不触发 reading 题材 崩溃', async ({ page }) => {
+        test.setTimeout(90000);
+        const errors = collectPageErrors(page);
+
+        await prepareLandingPage(page);
+        await openWorkbenchFromWorkshop(page);
+        await expectWorkbenchOpenedWithoutCrash(page, errors);
+
+        // 未选中小说时，工作台应停留在空态而不是错误边界降级页
+        await expect(page.locator('.novel-decomposition-workbench-backdrop')).toBeVisible();
+
+        await page.screenshot({
+            path: 'output/playwright/novel-decomposition-workbench-empty.png',
+            fullPage: false,
+        });
+    });
+
+    test('反复开关工作台仍保持稳定', async ({ page }) => {
+        test.setTimeout(120000);
+        const errors = collectPageErrors(page);
+
+        await prepareLandingPage(page);
+        await openWorkbenchFromWorkshop(page);
+        await expectWorkbenchOpenedWithoutCrash(page, errors);
+
+        const closeButton = page.getByRole('button', { name: '关闭', exact: true }).last();
+        await closeButton.click({ timeout: 5000 });
+        await expect(page.locator('.novel-decomposition-workbench-backdrop')).toHaveCount(0);
+
+        await openWorkbenchFromWorkshop(page);
+        await expectWorkbenchOpenedWithoutCrash(page, errors);
+    });
+
+    test('移动端窄屏打开工作台同样不崩溃', async ({ page }) => {
+        test.setTimeout(90000);
+        await page.setViewportSize({ width: 390, height: 844 });
+        const errors = collectPageErrors(page);
+
+        await prepareLandingPage(page);
+        await openWorkbenchFromWorkshop(page);
+        await expectWorkbenchOpenedWithoutCrash(page, errors);
+    });
+});

--- a/hooks/useNovelModePackCompletion.ts
+++ b/hooks/useNovelModePackCompletion.ts
@@ -32,6 +32,29 @@ export const 是否允许模式包完善运行回写 = (
     runToken: number
 ): boolean => activeTargetKey === runTargetKey && activeToken === runToken;
 
+/**
+ * 解析当前生效的模式包完善记录。
+ * [修复] 历史写法为 `record?.数据集ID === dataset?.id && record.题材 === baseMode`：
+ * 当工作台刚打开、尚未选中小说时 record 与 dataset 同时为 null，
+ * 前半段会退化成 `undefined === undefined` 判定为真，继续读取 `record.题材`
+ * 抛出 "Cannot read properties of null (reading '题材')" 导致工作台白屏。
+ * 这里显式要求 record 与 dataset 均非空后再比对，杜绝空值穿透。
+ */
+export const 解析当前小说模式包激活记录 = (
+    targetReady: boolean,
+    record: 小说模式包完善记录 | null | undefined,
+    dataset: 小说拆分数据集结构 | null | undefined,
+    baseMode: 题材模式类型
+): 小说模式包完善记录 | null => (
+    targetReady
+        && record != null
+        && dataset != null
+        && record.数据集ID === dataset.id
+        && record.题材 === baseMode
+        ? record
+        : null
+);
+
 export const 计算小说模式包完善界面状态 = (
     record: 小说模式包完善记录 | null,
     running: boolean,
@@ -121,11 +144,7 @@ export const useNovelModePackCompletion = (params: {
     const currentTargetReady = targetReady
         && readyTargetKeyRef.current === targetKey
         && readyDatasetRef.current === dataset;
-    const activeRecord = currentTargetReady
-        && record?.数据集ID === dataset?.id
-        && record.题材 === baseMode
-        ? record
-        : null;
+    const activeRecord = 解析当前小说模式包激活记录(currentTargetReady, record, dataset, baseMode);
 
     useEffect(() => {
         let active = true;


### PR DESCRIPTION
## 问题

打开「小说分解工作台」时报错并打开失败：

```
Cannot read properties of null (reading '题材')
```

## 根因

`hooks/useNovelModePackCompletion.ts` 中：

```ts
const activeRecord = currentTargetReady
    && record?.数据集ID === dataset?.id
    && record.题材 === baseMode
    ? record
    : null;
```

工作台刚打开、尚未选中小说时：

1. `dataset` 为 `null`，effect 走 `if (!dataset)` 分支把 `targetReady` 置为 `true`，且 `readyTargetKeyRef`/`readyDatasetRef` 与当前值一致，故 `currentTargetReady === true`；
2. `record` 也为 `null`，`record?.数据集ID` 与 `dataset?.id` 双双为 `undefined`，`undefined === undefined` 判定为真；
3. 于是继续求值 `record.题材`，在 `null` 上取属性直接抛出 `TypeError`。

该 hook 被 `NovelDecompositionSettings` 使用，而它正是工作台弹窗的内容主体，因此表现为「工作台打开失败」。

## 修复

抽出纯函数 `解析当前小说模式包激活记录`，显式要求 `record` 与 `dataset` 均非空后再比对数据集 ID 与题材，杜绝 `undefined === undefined` 的空值穿透；同时兼容记录 `数据集ID` 字段缺失的脏数据。

## 测试

新增 `__tests__/novelModePackCompletionNullDataset.test.tsx`（9 个用例），覆盖：

- 未选中小说时 `record`/`dataset` 同为 null（历史崩溃场景）
- 记录 `数据集ID` 缺失 + 未选中小说
- 已选中小说但无记录、进度未就绪、数据集不匹配、题材不匹配、正常命中
- 未选中小说时界面状态可安全计算
- 工作台首屏渲染不抛异常

已验证：把该函数改回旧写法后，测试会以完全相同的 `Cannot read properties of null (reading '题材')` 失败，说明是有效回归测试。

全量单测：216 个测试文件 / 1441 用例全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化小说模式包激活记录的判定逻辑，避免目标未就绪、记录或数据集缺失时发生异常。
  - 增加数据集与题材匹配校验，确保仅在条件完整且匹配成功时显示激活记录。
  - 改善未选择小说及数据加载未完成时的界面状态与错误防护。

- **测试**
  - 补充覆盖空值、缺失记录、加载状态、数据不匹配及正常匹配场景的测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->