### PR TITLE
fix: 修复行动选项误报缺失、glm 中转站 404、开局非流式设置失效

### DIFF
--- a/__tests__/chatCompletionClient.test.ts
+++ b/__tests__/chatCompletionClient.test.ts
@@ -120,6 +120,50 @@ describe('chatCompletionClient Claude compatible message normalization', () => {
         expect(String(fetchMock.mock.calls[0][0])).toBe('https://example.com/api/paas/v4/chat/completions');
     });
 
+    it('保留第三方中转站的 /v1 路径，不因模型名含 glm 改写成智谱私有的 /api/paas/v4', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+            choices: [{ message: { content: 'pong' } }]
+        }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+        }));
+
+        await 请求模型文本({
+            ...baseConfig,
+            baseUrl: 'https://relay.example.com/v1',
+            model: 'glm-4.6'
+        }, [{ role: 'user', content: 'ping' }], {
+            temperature: 1.0,
+            signal: undefined,
+            streamOptions: { stream: false },
+            errorDetailLimit: 500
+        });
+
+        expect(String(fetchMock.mock.calls[0][0])).toBe('https://relay.example.com/v1/chat/completions');
+    });
+
+    it('智谱官方域名仍然补全 /api/paas/v4/chat/completions', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+            choices: [{ message: { content: 'pong' } }]
+        }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+        }));
+
+        await 请求模型文本({
+            ...baseConfig,
+            baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+            model: 'glm-4.6'
+        }, [{ role: 'user', content: 'ping' }], {
+            temperature: 1.0,
+            signal: undefined,
+            streamOptions: { stream: false },
+            errorDetailLimit: 500
+        });
+
+        expect(String(fetchMock.mock.calls[0][0])).toBe('https://open.bigmodel.cn/api/paas/v4/chat/completions');
+    });
+
     it('strips Chinese display suffixes from OpenAI-compatible model ids before sending requests', async () => {
         expect(规范化请求模型名称('gemini-3.1-pro-high-search-真流-[星星公益站-CLI渠道]'))
             .toBe('gemini-3.1-pro-high-search');

--- a/__tests__/chatCompletionClient.test.ts
+++ b/__tests__/chatCompletionClient.test.ts
@@ -164,6 +164,28 @@ describe('chatCompletionClient Claude compatible message normalization', () => {
         expect(String(fetchMock.mock.calls[0][0])).toBe('https://open.bigmodel.cn/api/paas/v4/chat/completions');
     });
 
+    it('路径里出现 bigmodel.cn 的中转站不被误判为智谱官方域名', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+            choices: [{ message: { content: 'pong' } }]
+        }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+        }));
+
+        await 请求模型文本({
+            ...baseConfig,
+            baseUrl: 'https://relay.example.com/v1/bigmodel.cn/glm-4',
+            model: 'glm-4.6'
+        }, [{ role: 'user', content: 'ping' }], {
+            temperature: 1.0,
+            signal: undefined,
+            streamOptions: { stream: false },
+            errorDetailLimit: 500
+        });
+
+        expect(String(fetchMock.mock.calls[0][0])).toBe('https://relay.example.com/v1/bigmodel.cn/glm-4/chat/completions');
+    });
+
     it('strips Chinese display suffixes from OpenAI-compatible model ids before sending requests', async () => {
         expect(规范化请求模型名称('gemini-3.1-pro-high-search-真流-[星星公益站-CLI渠道]'))
             .toBe('gemini-3.1-pro-high-search');

--- a/__tests__/storyResponseParser.test.ts
+++ b/__tests__/storyResponseParser.test.ts
@@ -790,6 +790,24 @@ describe('storyResponseParser', () => {
         expect(parsed.tavern_commands && parsed.tavern_commands.length).toBeGreaterThan(0);
     });
 
+    it('裸正文后接 <options> 别名时，选项块不被吞入正文且解析正常', () => {
+        const parsed = parseStoryRawText([
+            '【旁白】陆凡站在礁石滩上，看着她头也不回地走远。',
+            '<options>',
+            'A. 先去南坡把野蜂窝处理干净',
+            'B. 陪柳青青一起准备下午的铺垫',
+            '</options>'
+        ].join('\n'), { requireActionOptionsTag: true, enableTagRepair: true });
+
+        expect(parsed.action_options).toEqual([
+            'A. 先去南坡把野蜂窝处理干净',
+            'B. 陪柳青青一起准备下午的铺垫'
+        ]);
+        expect(parsed.logs).toEqual([
+            { sender: '旁白', text: '陆凡站在礁石滩上，看着她头也不回地走远。' }
+        ]);
+    });
+
     it('reports concrete missing protocol tags instead of a generic parse failure', () => {
         try {
             parseStoryRawText([

--- a/__tests__/storyResponseParser.test.ts
+++ b/__tests__/storyResponseParser.test.ts
@@ -745,6 +745,51 @@ describe('storyResponseParser', () => {
         })).toThrow(/疑似输出在 <短期记忆> 内被截断|提高最大输出Token/);
     });
 
+    it('模型省略 <正文> 标签时，标签修复不会吞掉后面的 <行动选项>/<短期记忆>', () => {
+        const parsed = parseStoryRawText([
+            '【旁白】陆凡站在礁石滩上，看着她头也不回地走远。',
+            '<短期记忆>',
+            '陆凡到礁石滩找陆芹，帮她解开卡在石缝的蟹笼。',
+            '</短期记忆>',
+            '<行动选项>',
+            'A. 先去南坡把野蜂窝处理干净',
+            'B. 陪柳青青一起准备下午的铺垫',
+            'C. 带着陆荷陆养再去水洼边玩一会',
+            '</行动选项>'
+        ].join('\n'), { requireActionOptionsTag: true, enableTagRepair: true });
+
+        expect(parsed.action_options).toEqual([
+            'A. 先去南坡把野蜂窝处理干净',
+            'B. 陪柳青青一起准备下午的铺垫',
+            'C. 带着陆荷陆养再去水洼边玩一会'
+        ]);
+        expect(parsed.shortTerm).toBe('陆凡到礁石滩找陆芹，帮她解开卡在石缝的蟹笼。');
+        expect(parsed.logs).toEqual([
+            { sender: '旁白', text: '陆凡站在礁石滩上，看着她头也不回地走远。' }
+        ]);
+    });
+
+    it('思考区之后省略 <正文> 标签时同样保留命令与行动选项', () => {
+        const parsed = parseStoryRawText([
+            '<thinking>先规划本回合。</thinking>',
+            '【旁白】山风穿林而过。',
+            '【陆凡】“该动身了。”',
+            '<短期记忆>陆凡准备出发。</短期记忆>',
+            '<命令>set 陆凡.体力 = 80</命令>',
+            '<行动选项>',
+            'A. 立刻出发',
+            'B. 再等等',
+            '</行动选项>'
+        ].join('\n'), { requireActionOptionsTag: true, enableTagRepair: true });
+
+        expect(parsed.action_options).toEqual(['A. 立刻出发', 'B. 再等等']);
+        expect(parsed.logs).toEqual([
+            { sender: '旁白', text: '山风穿林而过。' },
+            { sender: '陆凡', text: '“该动身了。”' }
+        ]);
+        expect(parsed.tavern_commands && parsed.tavern_commands.length).toBeGreaterThan(0);
+    });
+
     it('reports concrete missing protocol tags instead of a generic parse failure', () => {
         try {
             parseStoryRawText([
@@ -757,7 +802,9 @@ describe('storyResponseParser', () => {
             expect(error).toBeInstanceOf(StoryResponseParseError);
             const parseError = error as StoryResponseParseError;
             expect(parseError.parseDetail || '').toMatch(/顶层标签顺序错误|正文/);
-            expect(parseError.protocolIssues || []).toContain('顶层标签顺序错误：<短期记忆> 出现在 <正文> 之前');
+            // 标签修复会在首个协议区块前补上 <正文> 空壳（而不是追加到文本末尾），
+            // 因此这里不再出现「标签顺序错误」，而是给出更准确的「正文内容为空」诊断。
+            expect(parseError.protocolIssues || []).toContain('<正文>...</正文> 内容为空');
         }
     });
 

--- a/hooks/useGame/worldGenerationWorkflow.ts
+++ b/hooks/useGame/worldGenerationWorkflow.ts
@@ -603,7 +603,7 @@ export const 执行世界生成工作流 = async (
         await deps.执行开场剧情生成(
             openingBase,
             finalPrompts,
-            openingStreaming,
+            openingRequestStreaming,
             currentApi,
             {
                 命令基态: deps.创建开场命令基态(openingBase),

--- a/hooks/useGame/worldGenerationWorkflow.ts
+++ b/hooks/useGame/worldGenerationWorkflow.ts
@@ -252,7 +252,15 @@ export const 执行世界生成工作流 = async (
         deps.setShowSettings(true);
         return;
     }
-    const openingRequestStreaming = openingStreaming && 开局阶段是否使用流式请求(currentApi);
+    // [修复] 开局主剧情请求此前只看新游戏面板的“流式开场”开关与供应商判断，
+    // 完全忽略设置里的全局“启用非流式输出”与分功能“主剧情非流式输出”。
+    // 结果是玩家打开非流式后开局依旧走流式（尤其快速重开会沿用旧快照里的 openingStreaming）。
+    // 这里与局内主剧情保持一致：任一非流式开关打开即强制非流式。
+    const 开局强制非流式输出 = normalizedGameConfig.启用非流式输出 === true
+        || deps.apiConfig?.功能模型占位?.主剧情非流式输出 === true;
+    const openingRequestStreaming = openingStreaming
+        && !开局强制非流式输出
+        && 开局阶段是否使用流式请求(currentApi);
 
     const normalizedOpeningExtraPrompt = (openingExtraPrompt || '').trim();
     const normalizedOpeningConfig = openingConfig

--- a/services/ai/chatCompletionClient.ts
+++ b/services/ai/chatCompletionClient.ts
@@ -1579,10 +1579,18 @@ const 构建OpenAI端点 = (
 
     const lowerModel = (modelRaw || '').toLowerCase();
     const isZhipuSupplier = supplier === 'zhipu';
+    const isZhipuHost = lowerBase.includes('bigmodel.cn');
+    // [修复] 模型名里带 glm 只是弱信号：第三方 OpenAI 兼容中转站（类脑、one-api 等）同样提供 glm-* 模型，
+    // 但它们的正确端点是 /v1/chat/completions。旧实现只要模型名含 glm 就把用户填写的 /v1 抹掉、
+    // 改写成智谱私有的 /api/paas/v4/chat/completions，导致这类中转站直接 404（模型列表能拉到、发消息就失败）。
+    // 因此只有在地址完全没有给出版本路径线索时，才允许按智谱网关补 /api/paas/v4；
+    // 用户已显式写出 /v1、/v4 或完整聊天端点时一律尊重原地址。
+    const 地址已给出版本线索 = /\/chat\/completions$/i.test(base)
+        || /\/v\d+$/i.test(base)
+        || OpenAI兼容地址已包含版本路径(去除OpenAI兼容聊天端点(base));
     const looksLikeZhipu = isZhipuSupplier
-        || lowerBase.includes('open.bigmodel.cn')
-        || lowerBase.includes('bigmodel.cn')
-        || lowerModel.includes('glm');
+        || isZhipuHost
+        || (lowerModel.includes('glm') && !地址已给出版本线索);
 
     if (looksLikeZhipu) {
         if (/\/api\/paas\/v4\/chat\/completions$/i.test(base) || /\/chat\/completions$/i.test(base)) return base;

--- a/services/ai/chatCompletionClient.ts
+++ b/services/ai/chatCompletionClient.ts
@@ -1579,7 +1579,16 @@ const 构建OpenAI端点 = (
 
     const lowerModel = (modelRaw || '').toLowerCase();
     const isZhipuSupplier = supplier === 'zhipu';
-    const isZhipuHost = lowerBase.includes('bigmodel.cn');
+    // [修复] 仅当 base 的 hostname 本身为 bigmodel.cn 或其子域时才视为智谱官方域名。
+    // 旧实现用 includes('bigmodel.cn') 会误命中路径里出现 bigmodel.cn 的中转站地址
+    //（如 https://relay.example.com/v1/bigmodel.cn/glm-4），把这类中转站错当成智谱官方并重写成 /api/paas/v4。
+    let isZhipuHost = false;
+    try {
+        const host = new URL(base).hostname.toLowerCase();
+        isZhipuHost = host === 'bigmodel.cn' || host.endsWith('.bigmodel.cn');
+    } catch {
+        isZhipuHost = lowerBase.includes('bigmodel.cn');
+    }
     // [修复] 模型名里带 glm 只是弱信号：第三方 OpenAI 兼容中转站（类脑、one-api 等）同样提供 glm-* 模型，
     // 但它们的正确端点是 /v1/chat/completions。旧实现只要模型名含 glm 就把用户填写的 /v1 抹掉、
     // 改写成智谱私有的 /api/paas/v4/chat/completions，导致这类中转站直接 404（模型列表能拉到、发消息就失败）。

--- a/services/ai/storyResponseParser.ts
+++ b/services/ai/storyResponseParser.ts
@@ -364,8 +364,10 @@ const 提取候选命令文本 = (text: string): string => {
 const 提取候选正文文本 = (text: string): string => {
     let stripped = 剥离酒馆元标签区块(text || '');
     for (const tag of ['剧情规划', '变量规划', '短期记忆', '命令', '行动选项', '动态世界', 'judge']) {
-        const escapedTag = 转义正则片段(tag);
-        stripped = stripped.replace(new RegExp(`<\\s*${escapedTag}\\s*>[\\s\\S]*?<\\s*/\\s*${escapedTag}\\s*>`, 'gi'), '\n');
+        for (const variant of 协议标签所有写法(tag)) {
+            const escapedTag = 转义正则片段(variant);
+            stripped = stripped.replace(new RegExp(`<\\s*${escapedTag}\\s*>[\\s\\S]*?<\\s*/\\s*${escapedTag}\\s*>`, 'gi'), '\n');
+        }
     }
     stripped = stripped
         .replace(/<\s*\/?\s*thinking\s*>/gi, '\n')
@@ -563,13 +565,22 @@ const 写入协议标签段 = (
 // 除 <正文> 外的协议区块标签，用于定位「裸正文」与结构化区块的分界点。
 const 正文之后协议区块标签: 可标题恢复标签[] = ['剧情规划', '变量规划', '短期记忆', '命令', '行动选项', '动态世界'];
 
+// 取某规范协议标签的全部写法（规范名 + 所有别名），供「裸正文包裹」与「候选正文提取」
+// 识别模型可能使用的缩写/英文别名（如 <选项> / <options> / <choice> 等）。
+const 协议标签所有写法 = (canonical: string): string[] => {
+    const aliases = Object.keys(协议标签别名映射).filter(k => 协议标签别名映射[k] === canonical);
+    return Array.from(new Set([canonical, ...aliases]));
+};
+
 const 定位首个协议区块位置 = (text: string): number => {
     let position = -1;
     for (const tag of 正文之后协议区块标签) {
-        const escapedTag = 转义正则片段(tag);
-        const matched = (text || '').match(new RegExp(`<\\s*${escapedTag}\\s*>`, 'i'));
-        if (matched && typeof matched.index === 'number' && (position < 0 || matched.index < position)) {
-            position = matched.index;
+        for (const variant of 协议标签所有写法(tag)) {
+            const escapedTag = 转义正则片段(variant);
+            const matched = (text || '').match(new RegExp(`<\\s*${escapedTag}\\s*>`, 'i'));
+            if (matched && typeof matched.index === 'number' && (position < 0 || matched.index < position)) {
+                position = matched.index;
+            }
         }
     }
     return position;

--- a/services/ai/storyResponseParser.ts
+++ b/services/ai/storyResponseParser.ts
@@ -560,6 +560,48 @@ const 写入协议标签段 = (
     return `${prefix}${lineBreak}<${tag}>${finalPayload}</${tag}>`;
 };
 
+// 除 <正文> 外的协议区块标签，用于定位「裸正文」与结构化区块的分界点。
+const 正文之后协议区块标签: 可标题恢复标签[] = ['剧情规划', '变量规划', '短期记忆', '命令', '行动选项', '动态世界'];
+
+const 定位首个协议区块位置 = (text: string): number => {
+    let position = -1;
+    for (const tag of 正文之后协议区块标签) {
+        const escapedTag = 转义正则片段(tag);
+        const matched = (text || '').match(new RegExp(`<\\s*${escapedTag}\\s*>`, 'i'));
+        if (matched && typeof matched.index === 'number' && (position < 0 || matched.index < position)) {
+            position = matched.index;
+        }
+    }
+    return position;
+};
+
+// [修复] 模型省略 <正文> 标签、直接输出裸正文时，旧实现把补全的 <正文> 追加到文本末尾。
+// 由于 提取首尾思考区段 会把「最后一个 <正文> 之前的全部内容」判定为思考区，
+// 追加在末尾会导致前面的 <短期记忆>/<行动选项>/<命令> 等区块被整体吞进思考区，
+// 进而误报「缺少 <行动选项> 标签」。此处改为在首个协议区块之前就地包裹裸正文。
+const 就地包裹裸正文 = (content: string, 正文候选: string): string => {
+    const text = content || '';
+    if (/<\s*正文\s*>/i.test(text)) return text;
+
+    const 首个协议位置 = 定位首个协议区块位置(text);
+    if (首个协议位置 < 0) return text;
+
+    const head = text.slice(0, 首个协议位置);
+    const tail = text.slice(首个协议位置);
+    const thinkingCloseMatches = [...head.matchAll(/<\s*\/\s*(?:thinking|think)\s*>/gi)];
+    const lastThinkingClose = thinkingCloseMatches.length > 0
+        ? thinkingCloseMatches[thinkingCloseMatches.length - 1]
+        : null;
+    const splitAt = lastThinkingClose && typeof lastThinkingClose.index === 'number'
+        ? lastThinkingClose.index + (lastThinkingClose[0] || '').length
+        : 0;
+    const 思考前缀 = head.slice(0, splitAt);
+    const 裸正文 = 提取候选正文文本(head.slice(splitAt)) || (正文候选 || '').trim();
+    const 前缀片段 = 思考前缀.trimEnd();
+
+    return `${前缀片段}${前缀片段 ? '\n' : ''}<正文>${裸正文}</正文>\n${tail}`;
+};
+
 const 补全协议缺失区块 = (content: string): string => {
     let text = content || '';
     const sections = 提取标题区块内容(text);
@@ -567,6 +609,7 @@ const 补全协议缺失区块 = (content: string): string => {
     const 短期候选 = sections.短期记忆 || '';
     const 命令候选 = sections.命令 || 提取候选命令文本(text);
 
+    text = 就地包裹裸正文(text, 正文候选);
     text = 写入协议标签段(text, '正文', 正文候选, { 允许空内容: true });
     text = 写入协议标签段(text, '短期记忆', 短期候选, { 缺失时默认内容: '无' });
     if (命令候选) {
@@ -782,6 +825,13 @@ const 分析标签协议缺失问题 = (text: string, options: Required<StoryPar
 
     if (!/<\s*正文\s*>/i.test(normalizedText) && /^(?:【[^】]+】|[^\n]{0,20}[：:]).+/m.test(normalizedText)) {
         issues.push('检测到疑似正文内容，但没有用 <正文>...</正文> 包裹');
+    }
+
+    // 标签修复会为缺失的正文补上空壳 <正文></正文>，此时上面的「缺少标签」分支不会命中，
+    // 需要单独提示正文为空，避免只剩下无意义的 JSON 解析错误。
+    const 正文区块匹配 = normalizedText.match(/<\s*正文\s*>([\s\S]*?)<\s*\/\s*正文\s*>/i);
+    if (正文区块匹配 && !(正文区块匹配[1] || '').trim()) {
+        issues.push('<正文>...</正文> 内容为空');
     }
 
     if (/(?:标签协议|输出格式|请按标签|完整闭合|只输出标签)/.test(normalizedText) && !/<\s*正文\s*>/i.test(normalizedText)) {


### PR DESCRIPTION
## 背景

今天玩家反馈的三个问题，逐一复现确认在当前 `main`（v1.0.645）上**仍然存在**，本 PR 全部修复并补了回归测试。

## 1. 明明有 `<行动选项>` 却报「缺少行动选项标签」

**复现**：模型省略 `<正文>` 标签、直接输出裸正文（弱模型很常见）：

```
【旁白】陆凡站在礁石滩上……
<短期记忆>……</短期记忆>
<行动选项>
A. ……
E. ……
</行动选项>
```

`enableTagRepair: true`（生产默认）→ 抛 `缺少 <行动选项>...</行动选项> 标签或标签内容为空`；
同一段文本 `enableTagRepair: false` → 正常解析出 5 个选项。

**根因链路**：
1. `补全协议缺失区块` 发现没有 `<正文>`，调用 `写入协议标签段` 补一个；
2. `写入协议标签段` 在标签不存在时是**追加到文本末尾**，于是 `<正文>` 落在 `</行动选项>` 之后；
3. `解析标签协议响应` 里的 `提取首尾思考区段` 以「**最后一个 `<正文>`**」为思考区/正文区分界；
4. 结果 `<短期记忆>` / `<命令>` / `<行动选项>` 全被判进思考区，`textWithoutThinking` 只剩 `<正文>…</正文>`；
5. `actionOptionsBlock` 为空 → `requireActionOptionsTag` 抛错。

**修复**：新增 `就地包裹裸正文`，在**首个协议区块之前**就地包裹裸正文（保留已有 `</thinking>` 前缀），不再追加到末尾。
顺带在 `分析标签协议缺失问题` 补上「`<正文>` 内容为空」诊断——补出空壳 `<正文></正文>` 后原「缺少标签」分支不再命中，否则报错会退化成无意义的 `Unexpected token '<' ... is not valid JSON`。

## 2. 第三方中转站的 `/v1` 被改写成 `/api/paas/v4` 导致 404

`构建OpenAI端点` 里 `looksLikeZhipu` 只要**模型名含 `glm`** 就成立，随后把用户填的 `/v1` 抹掉、拼成 `/api/paas/v4/chat/completions`。

但类脑、one-api 这类 OpenAI 兼容中转站同样提供 `glm-*` 模型，正确端点是 `/v1/chat/completions`。现象正好对得上玩家描述：**模型列表能正常拉到**（`构建OpenAI兼容模型列表候选地址` 本来就尊重 `/v1`），**一发消息就 404**。

**修复**：`glm` 模型名降级为弱信号——只有地址完全没给出版本路径线索时才当智谱处理；用户已显式写出 `/v1`、`/v4` 或完整聊天端点时一律尊重原地址。智谱官方域名（`bigmodel.cn`）与 `供应商 === 'zhipu'` 行为不变。

## 3. 开局不遵守「启用非流式输出」设置

`worldGenerationWorkflow.执行世界生成工作流` 里：

```ts
const openingRequestStreaming = openingStreaming && 开局阶段是否使用流式请求(currentApi);
```

只看新游戏面板的「流式开场」开关 + 供应商判断，**完全没读**设置里的全局 `启用非流式输出` 和分功能 `主剧情非流式输出`。快速重开还会沿用旧快照里的 `openingStreaming`，所以玩家改了设置也不生效。

**修复**：与局内主剧情保持一致，任一非流式开关打开即强制非流式。

## 测试

- 新增 4 条回归用例：
  - `storyResponseParser`：省略 `<正文>` 时不吞掉 `<行动选项>`/`<短期记忆>`；带 thinking 的同场景。
  - `chatCompletionClient`：中转站 `/v1` 保持不变；智谱官方域名仍补 `/api/paas/v4/chat/completions`。
- 调整 1 条旧用例断言：`reports concrete missing protocol tags…` 原本断言的「顶层标签顺序错误：`<短期记忆>` 出现在 `<正文>` 之前」正是本 bug 的副产物，修复后改为断言更准确的「`<正文>` 内容为空」。
- 全量 `vitest run`：**218 个测试文件 / 1460 用例通过，1 跳过**（含真实 AI 端到端用例）。
- `vite build` 通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化智谱及第三方中转服务的接口地址识别，避免错误改写已配置的路径。
  - 优化开局主剧情的非流式输出设置，确保相关配置生效。
  - 改进剧情响应解析：缺少正文标签时可正确修复并保留其他协议区块，同时明确识别空正文内容。

- **测试**
  - 新增接口地址识别及剧情响应解析场景测试，提升相关功能的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->