### PR TITLE
修复动态模块加载失败与 NPC 生图重复报错

### DIFF
--- a/__tests__/lazyImportWithReload.test.ts
+++ b/__tests__/lazyImportWithReload.test.ts
@@ -7,12 +7,12 @@ describe('lazyImportWithReload', () => {
         vi.unstubAllGlobals();
     });
 
-    it('does not refresh the page when a deployed chunk is no longer available', async () => {
+    it('refreshes once when a deployed chunk is no longer available', async () => {
         const reload = vi.fn();
         vi.stubGlobal('window', {
             location: { reload },
             sessionStorage: {
-                getItem: vi.fn(),
+                getItem: vi.fn().mockReturnValue(null),
                 setItem: vi.fn(),
                 removeItem: vi.fn()
             }
@@ -24,6 +24,23 @@ describe('lazyImportWithReload', () => {
             name: 'DynamicImportDeferredReloadError'
         });
 
+        expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('does not refresh repeatedly after the same chunk failure', async () => {
+        const reload = vi.fn();
+        vi.stubGlobal('window', {
+            location: { reload },
+            sessionStorage: {
+                getItem: vi.fn().mockReturnValue('1'),
+                setItem: vi.fn(),
+                removeItem: vi.fn()
+            }
+        });
+
+        await expect(lazyImportWithReload('game-panel', async () => {
+            throw new TypeError('Failed to fetch dynamically imported module');
+        })).rejects.toMatchObject({ name: 'DynamicImportDeferredReloadError' });
         expect(reload).not.toHaveBeenCalled();
     });
 

--- a/__tests__/lazyImportWithReload.test.ts
+++ b/__tests__/lazyImportWithReload.test.ts
@@ -7,41 +7,50 @@ describe('lazyImportWithReload', () => {
         vi.unstubAllGlobals();
     });
 
-    it('refreshes once when a deployed chunk is no longer available', async () => {
+    it('refreshes only once for repeated failures in the same session', async () => {
         const reload = vi.fn();
+        const values = new Map<string, string>();
+        const sessionStorage = {
+            getItem: vi.fn((key: string) => values.get(key) ?? null),
+            setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+            removeItem: vi.fn((key: string) => values.delete(key))
+        };
         vi.stubGlobal('window', {
             location: { reload },
-            sessionStorage: {
-                getItem: vi.fn().mockReturnValue(null),
-                setItem: vi.fn(),
-                removeItem: vi.fn()
-            }
+            sessionStorage
         });
 
-        await expect(lazyImportWithReload('game-panel', async () => {
+        const loader = async () => {
             throw new TypeError('Failed to fetch dynamically imported module');
-        })).rejects.toMatchObject({
+        };
+        await expect(lazyImportWithReload('game-panel', loader)).rejects.toMatchObject({
+            name: 'DynamicImportDeferredReloadError'
+        });
+        await expect(lazyImportWithReload('game-panel', loader)).rejects.toMatchObject({
             name: 'DynamicImportDeferredReloadError'
         });
 
+        expect(sessionStorage.setItem).toHaveBeenCalledOnce();
+        expect(sessionStorage.setItem).toHaveBeenCalledWith('moranjianghu:lazy-import-reload:game-panel', '1');
         expect(reload).toHaveBeenCalledOnce();
     });
 
-    it('does not refresh repeatedly after the same chunk failure', async () => {
-        const reload = vi.fn();
+    it('clears the reload marker after the module loads successfully', async () => {
+        const values = new Map([['moranjianghu:lazy-import-reload:game-panel', '1']]);
+        const sessionStorage = {
+            getItem: vi.fn((key: string) => values.get(key) ?? null),
+            setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+            removeItem: vi.fn((key: string) => values.delete(key))
+        };
         vi.stubGlobal('window', {
-            location: { reload },
-            sessionStorage: {
-                getItem: vi.fn().mockReturnValue('1'),
-                setItem: vi.fn(),
-                removeItem: vi.fn()
-            }
+            location: { reload: vi.fn() },
+            sessionStorage
         });
 
-        await expect(lazyImportWithReload('game-panel', async () => {
-            throw new TypeError('Failed to fetch dynamically imported module');
-        })).rejects.toMatchObject({ name: 'DynamicImportDeferredReloadError' });
-        expect(reload).not.toHaveBeenCalled();
+        await expect(lazyImportWithReload('game-panel', async () => ({ default: 'loaded' })))
+            .resolves.toEqual({ default: 'loaded' });
+        expect(sessionStorage.removeItem).toHaveBeenCalledWith('moranjianghu:lazy-import-reload:game-panel');
+        expect(values.has('moranjianghu:lazy-import-reload:game-panel')).toBe(false);
     });
 
     it('treats Safari text/html module MIME errors as deployed chunk failures', async () => {

--- a/__tests__/npcResourceCompletionSignature.test.ts
+++ b/__tests__/npcResourceCompletionSignature.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { 当前可用接口结构 } from '../utils/apiConfig';
+import { 构建主要角色资源补全配置签名 } from '../utils/npcResourceCompletionSignature';
+
+const 构建接口 = (overrides: Partial<当前可用接口结构> = {}): 当前可用接口结构 => ({
+    id: 'image',
+    名称: '文生图',
+    供应商: 'openai_compatible',
+    协议覆盖: 'auto',
+    baseUrl: 'https://example.com/v1',
+    apiKey: '',
+    model: 'image-model',
+    maxTokens: 0,
+    temperature: 0,
+    ...overrides
+});
+
+describe('构建主要角色资源补全配置签名', () => {
+    it('配置从不可用变为可用时会改变签名', () => {
+        const unavailable = 构建主要角色资源补全配置签名({
+            NPC生图已启用: true,
+            普通生图接口可用: false,
+            NSFW生图接口可用: false,
+            普通生图接口: 构建接口(),
+            NSFW生图接口: 构建接口({ 图片后端类型: 'comfyui' })
+        });
+        const available = 构建主要角色资源补全配置签名({
+            NPC生图已启用: true,
+            普通生图接口可用: true,
+            NSFW生图接口可用: true,
+            普通生图接口: 构建接口({ apiKey: 'configured-key' }),
+            NSFW生图接口: 构建接口({ 图片后端类型: 'comfyui', ComfyUI工作流JSON: '{"1":{}}' })
+        });
+
+        expect(available).not.toBe(unavailable);
+        expect(available).toContain('image-key:present');
+        expect(available).toContain('nsfw-workflow:present');
+    });
+
+    it('只记录敏感配置是否存在，不写入实际内容', () => {
+        const first = 构建主要角色资源补全配置签名({
+            NPC生图已启用: true,
+            普通生图接口可用: true,
+            NSFW生图接口可用: true,
+            普通生图接口: 构建接口({ apiKey: 'first-secret' }),
+            NSFW生图接口: 构建接口({ apiKey: 'second-secret', ComfyUI工作流JSON: '{"secret":"first"}' })
+        });
+        const second = 构建主要角色资源补全配置签名({
+            NPC生图已启用: true,
+            普通生图接口可用: true,
+            NSFW生图接口可用: true,
+            普通生图接口: 构建接口({ apiKey: 'replacement-secret' }),
+            NSFW生图接口: 构建接口({ apiKey: 'replacement-nsfw-secret', ComfyUI工作流JSON: '{"secret":"second"}' })
+        });
+
+        expect(second).toBe(first);
+        expect(first).not.toContain('first-secret');
+        expect(first).not.toContain('second-secret');
+        expect(first).not.toContain('"secret"');
+    });
+
+    it('NPC 生图开关变化时会改变签名', () => {
+        const base = {
+            普通生图接口可用: true,
+            NSFW生图接口可用: true,
+            普通生图接口: 构建接口({ apiKey: 'configured' }),
+            NSFW生图接口: 构建接口({ apiKey: 'configured' })
+        };
+
+        expect(构建主要角色资源补全配置签名({ ...base, NPC生图已启用: true }))
+            .not.toBe(构建主要角色资源补全配置签名({ ...base, NPC生图已启用: false }));
+    });
+});

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -2565,6 +2565,7 @@ export const useGame = () => {
     const 自动补齐NPC香闺秘档部位 = async (npc: any) => {
         const npcKey = 获取NPC唯一标识(npc);
         if (npcKey && NPC生图进行中Ref.current.has(npcKey)) return;
+        if (!接口配置是否可用(获取NSFW文生图接口配置(apiConfig))) return;
         const missingParts = 读取NPC香闺秘档缺失部位(npc);
         for (const part of missingParts) {
             try {
@@ -2710,6 +2711,8 @@ export const useGame = () => {
         if (npcList.length === 0) return;
         const config = 读取文生图功能配置();
         const 自动补图已启用 = config.总开关 && config.NPC开关;
+        const 普通生图接口可用 = 接口配置是否可用(获取文生图接口配置(apiConfig));
+        const NSFW生图接口可用 = 接口配置是否可用(获取NSFW文生图接口配置(apiConfig));
 
         for (const npc of npcList) {
             const npcId = typeof npc?.id === 'string' ? npc.id.trim() : '';
@@ -2718,7 +2721,7 @@ export const useGame = () => {
             await 确保NPC生图前角色锚点(npc);
             if (!自动补图已启用) continue;
 
-            if (!NPC是否已有成功构图(npc, ['头像'])) {
+            if (普通生图接口可用 && !NPC是否已有成功构图(npc, ['头像'])) {
                 if (全部NPC头像补全进行中Ref.current) {
                     输出NPC自动生图调试('跳过主要角色头像补全：全部 NPC 头像补全仍在进行中', { npcId });
                     continue;
@@ -2730,7 +2733,7 @@ export const useGame = () => {
                 }
             }
 
-            if ((NPC是否女性(npc) || (男娘NSFW内容已启用() && NPC是否男性或男娘(npc))) && !NPC是否已有成功构图(npc, ['半身', '立绘'])) {
+            if (普通生图接口可用 && (NPC是否女性(npc) || (男娘NSFW内容已启用() && NPC是否男性或男娘(npc))) && !NPC是否已有成功构图(npc, ['半身', '立绘'])) {
                 if (全部NPC头像补全进行中Ref.current) {
                     输出NPC自动生图调试('跳过主要角色展示图补全：全部 NPC 头像补全仍在进行中', { npcId });
                     continue;
@@ -2742,7 +2745,7 @@ export const useGame = () => {
                 }
             }
 
-            await 自动补齐NPC香闺秘档部位(npc);
+            if (NSFW生图接口可用) await 自动补齐NPC香闺秘档部位(npc);
         }
 
     };

--- a/hooks/useGame.ts
+++ b/hooks/useGame.ts
@@ -44,6 +44,7 @@ import { useGameState } from './useGameState';
 import { isTurnProcessing, shouldPlayTurnNotification } from '../utils/turnNotificationState';
 import { 规范化接口设置, 获取当前接口配置, 获取主剧情接口配置, 获取剧情回忆接口配置, 获取记忆总结接口配置, 获取文章优化接口配置, 获取变量计算接口配置, 获取世界演变接口配置, 获取文生图接口配置, 获取场景文生图接口配置, 获取NSFW文生图接口配置, 获取生图词组转化器接口配置, 获取生图画师串预设, 获取词组转化器预设提示词, 接口配置是否可用, 刷新已发现ComfyUI后端缓存, 变量校准功能已启用 as 变量生成功能已启用 } from '../utils/apiConfig';
 import type { 当前可用接口结构 } from '../utils/apiConfig';
+import { 构建主要角色资源补全配置签名 } from '../utils/npcResourceCompletionSignature';
 import {
     规范化记忆系统,
     规范化记忆配置,
@@ -2755,6 +2756,11 @@ export const useGame = () => {
         if (!missingSignature) return;
 
         const feature = apiConfig?.功能模型占位 as any;
+        const imageFeature = 读取文生图功能配置();
+        const 普通生图接口 = 获取文生图接口配置(apiConfig);
+        const NSFW生图接口 = 获取NSFW文生图接口配置(apiConfig);
+        const 普通生图接口可用 = 接口配置是否可用(普通生图接口);
+        const NSFW生图接口可用 = 接口配置是否可用(NSFW生图接口);
         const resourceSignature = [
             gameConfig?.启用NSFW模式 === true ? 'nsfw:on' : 'nsfw:off',
             gameConfig?.启用男娘NSFW内容 !== false ? 'femboy:on' : 'femboy:off',
@@ -2763,6 +2769,13 @@ export const useGame = () => {
             feature?.NSFW生图后端类型 || feature?.图片后端类型 || '',
             feature?.NSFW生图模型使用模型 || feature?.文生图模型使用模型 || '',
             feature?.NSFW生图模型API地址 || feature?.文生图模型API地址 || '',
+            构建主要角色资源补全配置签名({
+                NPC生图已启用: imageFeature.总开关 && imageFeature.NPC开关,
+                普通生图接口可用,
+                NSFW生图接口可用,
+                普通生图接口,
+                NSFW生图接口
+            }),
             missingSignature
         ].join('__');
         if (主要角色资源补全签名Ref.current === resourceSignature) return;

--- a/utils/lazyImportWithReload.ts
+++ b/utils/lazyImportWithReload.ts
@@ -22,14 +22,30 @@ export const lazyImportWithReload = async <T>(
     loader: () => Promise<T>
 ): Promise<T> => {
     try {
-        return await loader();
+        const result = await loader();
+        try {
+            window.sessionStorage.removeItem(`moranjianghu:lazy-import-reload:${importKey}`);
+        } catch {
+            // Storage cleanup is best-effort.
+        }
+        return result;
     } catch (error) {
         if (typeof window === 'undefined' || !isDynamicImportFetchError(error)) {
             throw error;
         }
 
+        const reloadKey = `moranjianghu:lazy-import-reload:${importKey}`;
+        try {
+            if (window.sessionStorage.getItem(reloadKey) !== '1') {
+                window.sessionStorage.setItem(reloadKey, '1');
+                window.location.reload();
+            }
+        } catch {
+            // Storage/reload is best-effort; preserve the actionable error below.
+        }
+
         const reloadSafeError = new Error(
-            `功能模块 ${importKey} 暂时无法加载。可能是版本刚更新导致旧页面仍在运行；为避免打断当前游玩，系统不会自动刷新页面。请先手动保存进度，方便时再刷新进入新版本。`
+            `功能模块 ${importKey} 暂时无法加载。系统已尝试刷新页面；请先手动保存进度，稍后重新进入新版本。`
         );
         reloadSafeError.name = 'DynamicImportDeferredReloadError';
         (reloadSafeError as Error & { cause?: unknown }).cause = error;

--- a/utils/npcResourceCompletionSignature.ts
+++ b/utils/npcResourceCompletionSignature.ts
@@ -1,0 +1,21 @@
+import type { 当前可用接口结构 } from './apiConfig';
+
+const 配置字段是否存在 = (value: unknown): boolean => (
+    typeof value === 'string' && value.trim().length > 0
+);
+
+export const 构建主要角色资源补全配置签名 = (options: {
+    NPC生图已启用: boolean;
+    普通生图接口可用: boolean;
+    NSFW生图接口可用: boolean;
+    普通生图接口: 当前可用接口结构 | null;
+    NSFW生图接口: 当前可用接口结构 | null;
+}): string => [
+    options.NPC生图已启用 ? 'npc:on' : 'npc:off',
+    options.普通生图接口可用 ? 'image-api:ready' : 'image-api:unavailable',
+    配置字段是否存在(options.普通生图接口?.apiKey) ? 'image-key:present' : 'image-key:missing',
+    配置字段是否存在(options.普通生图接口?.ComfyUI工作流JSON) ? 'image-workflow:present' : 'image-workflow:missing',
+    options.NSFW生图接口可用 ? 'nsfw-api:ready' : 'nsfw-api:unavailable',
+    配置字段是否存在(options.NSFW生图接口?.apiKey) ? 'nsfw-key:present' : 'nsfw-key:missing',
+    配置字段是否存在(options.NSFW生图接口?.ComfyUI工作流JSON) ? 'nsfw-workflow:present' : 'nsfw-workflow:missing'
+].join('__');


### PR DESCRIPTION
修复旧页面动态模块加载失败时的单次自动刷新兜底；在主要角色自动补全前校验文生图/NSFW接口，未配置时跳过任务。已通过 lazyImportWithReload 回归测试与 npm run build。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 动态内容加载失败时将自动刷新页面，避免重复刷新。
  - 加载恢复成功后会清理刷新状态，提升后续访问稳定性。
- **功能优化**
  - 自动补全图片前会检查对应图像生成服务是否可用。
  - 未配置相关服务时，将跳过相应生成任务，避免无效请求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->