### PR TITLE
fix: 修复拍卖行寄售收入被 AI 变量更新吞掉的竞态

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,7 +13,7 @@ import { ModalErrorBoundary } from './components/ui/ModalErrorBoundary';
 import { useGame } from './hooks/useGame';
 import { use图片资源回源预取 } from './hooks/useImageAssetPrefetch';
 import { normalizeCanonicalGameTime, 环境时间转标准串 } from './hooks/useGame/timeUtils';
-import { 获取主剧情接口配置, 获取文生图接口配置, 获取生图词组转化器接口配置, 获取记忆精炼接口配置, 接口配置是否可用 } from './utils/apiConfig';
+import { 获取主剧情接口配置, 获取文生图接口配置, 获取生图词组转化器接口配置, 获取记忆精炼接口配置, 接口配置是否可用, 获取变量计算接口配置, 变量校准功能已启用 as 变量生成功能已启用 } from './utils/apiConfig';
 import { 请求模型文本 } from './services/ai/chatCompletionClient';
 import { 记忆精炼系统提示词 } from './prompts/runtime/memoryRefine';
 import { 获取内置世界书槽位内容 } from './utils/worldbook';
@@ -32,8 +32,9 @@ import { checkForAppUpdate, downloadLatestApkPackage, subscribeAppUpdateProgress
 import { APK仅手动更新已启用 } from './utils/appUpdatePreferences';
 import { RELEASE_INFO } from './data/releaseInfo';
 import { fetchRuntimeReleaseInfo, type RuntimeReleaseInfo } from './services/runtimeReleaseInfo';
-import { 读取拍卖行状态, 保存拍卖行状态, 清理并补货, 投放事件拍卖品, 构建拍卖行存储作用域, 上架背包物品, 创建交易记录, 结算玩家寄售, 从势力互动投放拍卖品, type 拍卖行状态 } from './services/auctionHouse';
+import { 读取拍卖行状态, 保存拍卖行状态, 清理并补货, 投放事件拍卖品, 构建拍卖行存储作用域, 上架背包物品, 创建交易记录, 结算玩家寄售, 从势力互动投放拍卖品, 自动增加BaseAmount, type 拍卖行状态 } from './services/auctionHouse';
 import { 获取货币显示模式, 规范化角色金钱 } from './utils/currencyDisplay';
+import { addScriptedMoneyDelta } from './utils/scriptedMoneyReconciler';
 import { 获取题材界面文案 } from './utils/resourceLabels';
 import { 获取题材顶部时间显示格式 } from './utils/modeRuntimeProfile';
 import { 计算游戏历程天数 } from './utils/gameTimeJourney';
@@ -1265,16 +1266,25 @@ const App: React.FC = () => {
         const signature = `${latestAssistantMessage.timestamp || 0}-${latestAssistantMessage.gameTime || ''}`;
         if (auctionSettlementHandledRef.current.has(signature)) return;
         auctionSettlementHandledRef.current.add(signature);
-        setAuctionHouseState((prev) => {
-            const settled = 结算玩家寄售(prev, state.角色, latestAssistantMessage.timestamp || Date.now(), auctionCurrencyOptions);
-            if (!settled.settledCount) return prev;
-            保存拍卖行状态(settled.nextState, auctionHouseScope);
-            setters.setCharacter(settled.nextCharacter);
-            void actions.performAutoSave?.({ role: settled.nextCharacter, force: true });
-            actions.pushNotification({ title: '寄售成交', message: settled.message, tone: 'success' });
-            return settled.nextState;
-        });
-    }, [actions, auctionCurrencyOptions, auctionHouseScope, latestAssistantMessage, setters, state.角色]);
+        // 在 effect 体内（而非 setState updater 内）计算与落地：React StrictMode 会双调用 updater，
+        // 把累加型副作用 addScriptedMoneyDelta 放进 updater 会导致金额翻倍。
+        const settled = 结算玩家寄售(auctionHouseState, state.角色, latestAssistantMessage.timestamp || Date.now(), auctionCurrencyOptions);
+        if (!settled.settledCount) return;
+        保存拍卖行状态(settled.nextState, auctionHouseScope);
+        const 变量生成启用 = 变量生成功能已启用(state.apiConfig) && 接口配置是否可用(获取变量计算接口配置(state.apiConfig));
+        if (!变量生成启用) {
+            // 变量模型不启用时，没有命令处理器代为落地，这里直接把拍卖收入叠加到底层金额并立即存档。
+            const 加钱后角色 = 自动增加BaseAmount(state.角色, settled.totalBaseAmount, auctionCurrencyOptions);
+            setters.setCharacter(加钱后角色);
+            void actions.performAutoSave?.({ role: 加钱后角色, force: true });
+        } else if (settled.totalBaseAmount > 0) {
+            // 变量模型启用时，只登记增量到全局累加器，由变量命令处理器在应用 AI 命令后、落地前叠加，
+            // 避免被变量模型基于旧快照的「绝对 set 角色.金钱」命令覆盖（玩家反馈：下回合脚本加的钱被变量更新吞了）。
+            addScriptedMoneyDelta(settled.totalBaseAmount);
+        }
+        actions.pushNotification({ title: '寄售成交', message: settled.message, tone: 'success' });
+        setAuctionHouseState(settled.nextState);
+    }, [actions, auctionCurrencyOptions, auctionHouseScope, latestAssistantMessage, setters, state.角色, auctionHouseState]);
     // [已移除] 拍卖行物品不再从主角剧情正文中提取，改为从世界势力互动事件中自然流出。
     // 旧逻辑：从剧情响应构建拍卖行投放参数列表 → 投放事件拍卖品
     // 新逻辑：世界演化 → 势力互动 → 世界.拍卖行待投放物品 → 从势力互动投放拍卖品

--- a/__tests__/scriptedMoneyReconciliation.test.ts
+++ b/__tests__/scriptedMoneyReconciliation.test.ts
@@ -104,4 +104,28 @@ describe('scripted money reconciliation vs variable model', () => {
         } as any, state, deps as any, undefined, { applyState: false }) as any;
         expect(计算金钱BaseAmount总值(result.角色.金钱)).toBe(150);
     });
+
+    it('模拟(applyState:false)只预览不消费增量，真实落地(applyState:true)才消费——修复 CodeRabbit 指出的 High 风险', () => {
+        addScriptedMoneyDelta(50);
+        const resp = {
+            logs: [{ sender: '旁白', text: '账房结算寄售。' }],
+            tavern_commands: [
+                // AI 变量模型基于旧快照给出绝对金额（未包含本回合拍卖收入）
+                { action: 'set', key: '角色.金钱', value: { 底层货币: 100 } }
+            ]
+        } as any;
+        const 造状态 = () => {
+            const s = 构建基础状态();
+            s.角色 = { 姓名: '杨培强', 金钱: { 底层货币: 100 } } as any;
+            return s;
+        };
+        // 模拟/预览阶段：结果应叠加增量，但累加器不被消费，供后续真实落地使用
+        const simResult = 执行响应命令处理(resp, 造状态(), deps as any, undefined, { applyState: false }) as any;
+        expect(计算金钱BaseAmount总值(simResult.角色.金钱)).toBe(150);
+        expect(peekScriptedMoneyDelta()).toBe(50);
+        // 真实落地阶段：再次叠加并消费累加器
+        const realResult = 执行响应命令处理(resp, 造状态(), deps as any, undefined, { applyState: true }) as any;
+        expect(计算金钱BaseAmount总值(realResult.角色.金钱)).toBe(150);
+        expect(peekScriptedMoneyDelta()).toBe(0);
+    });
 });

--- a/__tests__/scriptedMoneyReconciliation.test.ts
+++ b/__tests__/scriptedMoneyReconciliation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { 执行响应命令处理, 响应命令处理状态 } from '../hooks/useGame/responseCommandProcessor';
+import { 规范化社交列表 } from '../hooks/useGame/stateTransforms';
+import { 计算金钱BaseAmount总值 } from '../services/auctionHouse';
+import {
+    addScriptedMoneyDelta,
+    consumeScriptedMoneyDelta,
+    peekScriptedMoneyDelta,
+    resetScriptedMoneyDelta
+} from '../utils/scriptedMoneyReconciler';
+
+// ── 累加器单元测试 ──────────────────────────────────────────────
+describe('scriptedMoneyReconciler accumulator', () => {
+    beforeEach(() => resetScriptedMoneyDelta());
+
+    it('累加正数增量，consume 后清零', () => {
+        addScriptedMoneyDelta(30);
+        addScriptedMoneyDelta(20);
+        expect(peekScriptedMoneyDelta()).toBe(50);
+        expect(consumeScriptedMoneyDelta()).toBe(50);
+        expect(peekScriptedMoneyDelta()).toBe(0);
+    });
+
+    it('忽略负数与非法值，避免脚本误登记导致金额异常', () => {
+        addScriptedMoneyDelta(-100);
+        addScriptedMoneyDelta(NaN);
+        addScriptedMoneyDelta(0);
+        expect(peekScriptedMoneyDelta()).toBe(0);
+    });
+
+    it('reset 可清除未消费的残留增量（应对上一轮中断）', () => {
+        addScriptedMoneyDelta(999);
+        resetScriptedMoneyDelta();
+        expect(peekScriptedMoneyDelta()).toBe(0);
+    });
+});
+
+// ── 端到端：脚本化金钱对账 ──────────────────────────────────────
+const 构建基础状态 = (): 响应命令处理状态 => ({
+    角色: { 姓名: '杨培强' } as any,
+    环境: {} as any,
+    社交: [],
+    世界: {} as any,
+    战斗: {} as any,
+    玩家门派: {} as any,
+    任务列表: [],
+    约定列表: [],
+    剧情: {} as any,
+    剧情规划: {} as any
+});
+
+const deps = {
+    规范化环境信息: (value?: any) => value || {},
+    规范化社交列表,
+    规范化世界状态: (value?: any) => value || {},
+    规范化战斗状态: (value?: any) => value || {},
+    规范化门派状态: (value?: any) => value || {},
+    规范化剧情状态: (value?: any) => value || {},
+    规范化剧情规划状态: (value?: any) => value || {},
+    规范化女主剧情规划状态: (value?: any) => value,
+    规范化同人剧情规划状态: (value?: any) => value,
+    规范化同人女主剧情规划状态: (value?: any) => value,
+    规范化角色物品容器映射: (value?: any) => value || {},
+    战斗结束自动清空: (value?: any) => value || {}
+};
+
+describe('scripted money reconciliation vs variable model', () => {
+    beforeEach(() => resetScriptedMoneyDelta());
+
+    it('AI 绝对 set 角色.金钱 之后仍保留脚本登记的拍卖收入（修复：下回合脚本加的钱被变量更新吞了）', () => {
+        const state = 构建基础状态();
+        state.角色 = { 姓名: '杨培强', 金钱: { 底层货币: 100 } } as any;
+        // 模拟拍卖行结算脚本在变量模型启用路径下登记的增量
+        addScriptedMoneyDelta(50);
+        const result = 执行响应命令处理({
+            logs: [{ sender: '旁白', text: '夜深，账房结算。' }],
+            tavern_commands: [
+                // AI 变量模型基于旧快照给出绝对金额（未包含本回合拍卖收入）
+                { action: 'set', key: '角色.金钱', value: { 底层货币: 100 } }
+            ]
+        } as any, state, deps as any, undefined, { applyState: false }) as any;
+        expect(计算金钱BaseAmount总值(result.角色.金钱)).toBe(150);
+    });
+
+    it('未登记脚本增量时，AI 的绝对 set 金额不被篡改', () => {
+        const state = 构建基础状态();
+        state.角色 = { 姓名: '杨培强', 金钱: { 底层货币: 100 } } as any;
+        const result = 执行响应命令处理({
+            logs: [{ sender: '旁白', text: '无事发生。' }],
+            tavern_commands: [
+                { action: 'set', key: '角色.金钱', value: { 底层货币: 100 } }
+            ]
+        } as any, state, deps as any, undefined, { applyState: false }) as any;
+        expect(计算金钱BaseAmount总值(result.角色.金钱)).toBe(100);
+    });
+
+    it('变量模型未下发金钱命令时，脚本增量也正确叠加到当前金额上', () => {
+        const state = 构建基础状态();
+        state.角色 = { 姓名: '杨培强', 金钱: { 底层货币: 80 } } as any;
+        addScriptedMoneyDelta(70);
+        const result = 执行响应命令处理({
+            logs: [{ sender: '旁白', text: '江湖买家取走了寄售的货物。' }],
+            tavern_commands: []
+        } as any, state, deps as any, undefined, { applyState: false }) as any;
+        expect(计算金钱BaseAmount总值(result.角色.金钱)).toBe(150);
+    });
+});

--- a/hooks/useGame/responseCommandProcessor.ts
+++ b/hooks/useGame/responseCommandProcessor.ts
@@ -24,7 +24,7 @@ import type { 境界配置 } from '../../utils/realmConfig';
 import { 提取NPC死亡风险命令索引, 状态效果是死亡判定 } from '../../utils/npcDeathGuard';
 import { 构建体内射精记录, 推进社交孕产状态, 规范化孕产时间 } from '../../utils/reproduction';
 import { 自动增加BaseAmount } from '../../services/auctionHouse';
-import { consumeScriptedMoneyDelta } from '../../utils/scriptedMoneyReconciler';
+import { consumeScriptedMoneyDelta, peekScriptedMoneyDelta } from '../../utils/scriptedMoneyReconciler';
 
 /** 判断是否为具体地点变更命令（多货币汇率系统用） */
 const 是否具体地点变更命令 = (key: string): boolean => {
@@ -1565,13 +1565,19 @@ const 过滤玩家本人门派成员 = (sect: any, playerName?: string): any => 
 
 /**
  * 脚本化金钱增量对账：
- * 取出本回合脚本/系统侧（拍卖行寄售结算等）登记的金钱增量并叠加到角色底层金额，
+ * 取出（或预览）本回合脚本/系统侧（拍卖行寄售结算等）登记的金钱增量并叠加到角色底层金额，
  * 保证它不会被 AI 变量模型基于旧快照的绝对 `set 角色.金钱` 命令覆盖掉。
  * 必须在所有 AI 命令应用完毕、且 `结算已完成任务奖励` 之后调用，落地前最后一步叠加。
+ *
+ * 关键：仅在「真正落地」(shouldApplyState=true) 时消费增量；
+ * 模拟/预览 (applyState:false) 只预览、不消费，避免增量在真实状态更新前被提前吞掉，
+ * 否则会出现 CodeRabbit 指出的「模拟阶段消费掉收入、真实落地时再次丢失」问题。
+ *
+ * @param 是否落地 为 true 时消费并清零累加器；为 false 时仅读取（peek）不消费。
  */
-const 应用脚本化金钱对账 = (角色: 角色数据结构 | undefined): 角色数据结构 => {
+const 应用脚本化金钱对账 = (角色: 角色数据结构 | undefined, 是否落地: boolean): 角色数据结构 => {
     if (!角色 || typeof 角色 !== 'object') return 角色 as 角色数据结构;
-    const delta = consumeScriptedMoneyDelta();
+    const delta = 是否落地 ? consumeScriptedMoneyDelta() : peekScriptedMoneyDelta();
     if (delta > 0) {
         return 自动增加BaseAmount(角色, delta);
     }
@@ -1863,7 +1869,8 @@ export const 执行响应命令处理 = (
         }
 
         // 脚本化金钱增量对账：在 `设置角色` 落地前叠加，避免被 AI 绝对 set 覆盖
-        finalState = { ...finalState, 角色: 应用脚本化金钱对账(finalState.角色) };
+        // 模拟/预览(shouldApplyState=false)只预览不消费，仅真实落地时消费增量（修复 CodeRabbit High 风险）
+        finalState = { ...finalState, 角色: 应用脚本化金钱对账(finalState.角色, shouldApplyState) };
 
         if (shouldApplyState) {
             deps.设置角色?.(finalState.角色);
@@ -1976,7 +1983,8 @@ export const 执行响应命令处理 = (
         finalState = 'state' in calibrated ? calibrated.state : calibrated;
     };
     // 脚本化金钱增量对账：在 `设置角色` 落地前叠加，避免被 AI 绝对 set 覆盖
-    finalState = { ...finalState, 角色: 应用脚本化金钱对账(finalState.角色) };
+    // 模拟/预览(shouldApplyState=false)只预览不消费，仅真实落地时消费增量（修复 CodeRabbit High 风险）
+    finalState = { ...finalState, 角色: 应用脚本化金钱对账(finalState.角色, shouldApplyState) };
 
     if (shouldApplyState) {
         deps.设置角色?.(finalState.角色);

--- a/hooks/useGame/responseCommandProcessor.ts
+++ b/hooks/useGame/responseCommandProcessor.ts
@@ -23,6 +23,8 @@ import { 提取NPC境界回退风险命令索引 } from '../../utils/npcRealmReg
 import type { 境界配置 } from '../../utils/realmConfig';
 import { 提取NPC死亡风险命令索引, 状态效果是死亡判定 } from '../../utils/npcDeathGuard';
 import { 构建体内射精记录, 推进社交孕产状态, 规范化孕产时间 } from '../../utils/reproduction';
+import { 自动增加BaseAmount } from '../../services/auctionHouse';
+import { consumeScriptedMoneyDelta } from '../../utils/scriptedMoneyReconciler';
 
 /** 判断是否为具体地点变更命令（多货币汇率系统用） */
 const 是否具体地点变更命令 = (key: string): boolean => {
@@ -1561,6 +1563,21 @@ const 过滤玩家本人门派成员 = (sect: any, playerName?: string): any => 
         : { ...sect, 重要成员: nextMembers };
 };
 
+/**
+ * 脚本化金钱增量对账：
+ * 取出本回合脚本/系统侧（拍卖行寄售结算等）登记的金钱增量并叠加到角色底层金额，
+ * 保证它不会被 AI 变量模型基于旧快照的绝对 `set 角色.金钱` 命令覆盖掉。
+ * 必须在所有 AI 命令应用完毕、且 `结算已完成任务奖励` 之后调用，落地前最后一步叠加。
+ */
+const 应用脚本化金钱对账 = (角色: 角色数据结构 | undefined): 角色数据结构 => {
+    if (!角色 || typeof 角色 !== 'object') return 角色 as 角色数据结构;
+    const delta = consumeScriptedMoneyDelta();
+    if (delta > 0) {
+        return 自动增加BaseAmount(角色, delta);
+    }
+    return 角色;
+};
+
 export const 执行响应命令处理 = (
     response: GameResponse,
     currentState: 响应命令处理状态,
@@ -1845,6 +1862,9 @@ export const 执行响应命令处理 = (
             finalState = 'state' in calibrated ? calibrated.state : calibrated;
         }
 
+        // 脚本化金钱增量对账：在 `设置角色` 落地前叠加，避免被 AI 绝对 set 覆盖
+        finalState = { ...finalState, 角色: 应用脚本化金钱对账(finalState.角色) };
+
         if (shouldApplyState) {
             deps.设置角色?.(finalState.角色);
             deps.设置环境?.(finalState.环境);
@@ -1955,6 +1975,9 @@ export const 执行响应命令处理 = (
     if (calibrated) {
         finalState = 'state' in calibrated ? calibrated.state : calibrated;
     };
+    // 脚本化金钱增量对账：在 `设置角色` 落地前叠加，避免被 AI 绝对 set 覆盖
+    finalState = { ...finalState, 角色: 应用脚本化金钱对账(finalState.角色) };
+
     if (shouldApplyState) {
         deps.设置角色?.(finalState.角色);
         deps.设置环境?.(finalState.环境);

--- a/hooks/useGame/sendWorkflow.ts
+++ b/hooks/useGame/sendWorkflow.ts
@@ -30,6 +30,7 @@ import { 检测社交删除风险命令 } from '../../utils/npcRetentionGuard';
 import { 检测NPC境界回退风险命令 } from '../../utils/npcRealmRegressionGuard';
 import { 获取境界配置, type 境界配置 } from '../../utils/realmConfig';
 import { 构建标签缺失补充提示 } from '../../utils/parseErrorHints';
+import { resetScriptedMoneyDelta } from '../../utils/scriptedMoneyReconciler';
 import { 对AI输出执行酒馆正则 } from '../../utils/tavernRegexEngine';
 import { 提取酒馆选项 } from '../../utils/tavernOptionRenderer';
 import { 获取预设已分类正则脚本 } from '../../utils/tavernPreset';
@@ -2234,6 +2235,9 @@ export const 执行主剧情发送工作流 = async (
             return simulatedState;
         };
         await 让出主线程();
+        // 回合主流程命令应用前：清空上一轮（可能中断未消费）残留的脚本化金钱增量，
+        // 避免污染本轮。拍卖结算增量会由 App.tsx 的结算 effect 在本回合稍后登记进来。
+        resetScriptedMoneyDelta();
         const immediateState = 计时同步队列步骤(
             "main.applyImmediateResponseCommands",
             () => deps.processResponseCommands(finalParsedResponse, mainCommandBaseState),

--- a/utils/scriptedMoneyReconciler.ts
+++ b/utils/scriptedMoneyReconciler.ts
@@ -1,0 +1,45 @@
+/**
+ * 脚本化金钱增量对账器
+ *
+ * 问题背景：
+ * 拍卖行「玩家寄售」会在下回合自动成交，由脚本通过 `自动增加BaseAmount`
+ * 给角色加钱。但 AI 变量模型每条消息都会基于「当前快照」生成
+ * `set 角色.金钱 = {...}` 这种绝对命令，且它属于异步 AI 调用，落地时间
+ * 晚于同步的拍卖结算 `setCharacter`。结果就是：变量更新用旧快照值把脚本刚
+ * 加的钱覆盖掉了（玩家反馈：下回合脚本加的钱被变量更新吞了）。
+ *
+ * 解决方案：
+ * 脚本化系统（拍卖结算等）不再直接抢写 `角色.金钱`，而是把本回合的金钱增量
+ * 登记到这里的累加器；变量命令处理器 `执行响应命令处理` 在应用完 AI 命令、
+ * 调用 `设置角色` 落地之前，再把这笔增量叠加回去。这样无论 AI 是否发了金钱
+ * 命令、无论落地先后，脚本收入都不会丢失。
+ *
+ * 注意：
+ * - 累加器是进程级单例，只在一次游戏内使用；变量模型开始新一轮校准时会先
+ *   `resetScriptedMoneyDelta()` 清掉上一轮（可能因中断而残留）的增量。
+ * - 使命名清晰：只在「脚本/系统侧主动加钱」时调用 `addScriptedMoneyDelta`，
+ *   不要在 AI 命令处理器内部重复登记。
+ */
+
+let pendingScriptedMoneyDelta = 0;
+
+/** 登记一笔脚本化金钱增量（底层金额 baseAmount，单位与 `自动增加BaseAmount` 一致）。 */
+export const addScriptedMoneyDelta = (amount: number): void => {
+    const value = Math.max(0, Math.floor(Number(amount) || 0));
+    pendingScriptedMoneyDelta += value;
+};
+
+/** 取出并清零当前累计的脚本化金钱增量；若无则返回 0。 */
+export const consumeScriptedMoneyDelta = (): number => {
+    const value = pendingScriptedMoneyDelta;
+    pendingScriptedMoneyDelta = 0;
+    return value;
+};
+
+/** 只读查看当前累计增量（用于调试/测试）。 */
+export const peekScriptedMoneyDelta = (): number => pendingScriptedMoneyDelta;
+
+/** 清零累计增量（变量模型开启新一轮校准时调用，避免上一轮残留污染本轮）。 */
+export const resetScriptedMoneyDelta = (): void => {
+    pendingScriptedMoneyDelta = 0;
+};


### PR DESCRIPTION
## 概述
修复玩家寄售收入被 AI 变量更新「吞掉」的竞态：物品挂在天下拍卖行成交后，下回合脚本加的钱被变量模型基于旧快照的绝对 \`set 角色.金钱\` 命令覆盖。

## 问题根因
- 拍卖行「玩家寄售」在回合切换时由脚本通过 \`自动增加BaseAmount\` 给角色加钱（同步、在 React effect 中落地）。
- AI 变量模型每条消息异步生成绝对 \`set 角色.金钱 = {...}\` 命令，基于「当前快照」，且属于异步调用，落地时间晚于同步结算。
- 结果：变量更新用旧快照值覆盖脚本刚加的钱，表现为玩家反馈的「下回合脚本加的钱被变量更新给吞了」。

## 修复方案
- 新增 \`utils/scriptedMoneyReconciler.ts\`：进程级累加器，脚本侧只负责 \`addScriptedMoneyDelta\` 登记金钱增量，不直接抢写 \`角色.金钱\`。
- \`执行响应命令处理\`（responseCommandProcessor.ts）在应用完所有 AI 命令、\`设置角色\` 落地前，调用 \`应用脚本化金钱对账\` 把增量叠加回去 —— 顺序无关、回合无关，脚本收入不再丢失。
- 修复 React StrictMode 下 \`setState\` updater 内累加型副作用导致金额翻倍的问题：拍卖结算副作用已移出 updater 到 effect 体内。
- 重置逻辑收敛到主流程回合起点（sendWorkflow.ts 的 \`resetScriptedMoneyDelta\`），不在变量校准协调器里重置，避免清掉本回合已登记的增量。

## 测试验证
- 新增 \`__tests__/scriptedMoneyReconciliation.test.ts\`（6 项全过）：覆盖「AI 绝对 set + 脚本增量」「无增量保留 AI 值」「无 AI 命令 + 脚本增量」三类场景。
- \`responseCommandProcessor\` 既有测试 109 项全过，无回归。

## 影响范围
仅影响拍卖行寄售成交后的金钱结算链路；变量校准、主流程命令处理行为不变。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 优化拍卖行寄售结算，确保获得的金钱正确计入角色余额。
  * 改善变量模型启用时的金钱更新，避免结算收入被旧数据覆盖。
  * 支持脚本及系统产生的金钱增量统一对账与应用。

* **错误修复**
  * 修复回合处理过程中金钱增量残留、丢失或重复应用的问题。
  * 忽略无效金额输入，并在新回合开始时清理上一回合的残留数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->