### PR TITLE
fix: 修复 AI 金钱别名更新被旧三层货币字段反向吞掉的竞态

### DIFF
--- a/__tests__/moneyCommandWriteThrough.test.ts
+++ b/__tests__/moneyCommandWriteThrough.test.ts
@@ -69,6 +69,30 @@ describe('同步金钱命令写入（纯函数）', () => {
         expect(计算金钱BaseAmount总值(next.金钱)).toBe(6270000);
     });
 
+    it('只写 baseAmount 时，存档中残留的题材别名（灵石）也对齐到分解后的层级值', () => {
+        const money = { ...构建双重字段金钱({ baseAmount: 3501234 }), 灵石: 3500 };
+        const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['baseAmount'])) as any;
+        // 默认武侠汇率分解 3,501,234 = 35 上层 + 1 中层 + 234 底层
+        expect(next.金钱.底层货币).toBe(234);
+        expect(next.金钱.灵石).toBe(234);
+        expect(next.金钱.铜钱).toBe(234);
+        expect(next.金钱.baseAmount).toBe(3501234);
+    });
+
+    it('写别名路径同样对齐已存在的题材别名（灵晶 为中层别名）', () => {
+        const money = { ...构建双重字段金钱({ 银子: 4000 }), 灵晶: 3500 };
+        const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['银子'])) as any;
+        expect(next.金钱.中层货币).toBe(4000);
+        expect(next.金钱.灵晶).toBe(4000);
+    });
+
+    it('题材别名同步只覆盖已存在字段，不为无关题材新增键', () => {
+        const money = 构建双重字段金钱({ 银子: 4000 });
+        const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['银子'])) as any;
+        expect(Object.prototype.hasOwnProperty.call(next.金钱, '灵晶')).toBe(false);
+        expect(Object.prototype.hasOwnProperty.call(next.金钱, '灵石')).toBe(false);
+    });
+
     it('题材别名（灵石）写入 → 底层货币同步', () => {
         const money = 构建双重字段金钱({ 灵石: 500 });
         const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['灵石'])) as any;

--- a/__tests__/moneyCommandWriteThrough.test.ts
+++ b/__tests__/moneyCommandWriteThrough.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { 执行响应命令处理, 响应命令处理状态 } from '../hooks/useGame/responseCommandProcessor';
+import { 规范化社交列表, 提取金钱命令字段, 同步金钱命令写入 } from '../hooks/useGame/stateTransforms';
+import { 计算金钱BaseAmount总值 } from '../services/auctionHouse';
+
+/**
+ * 金钱命令写穿透回归（玩家反馈：AI set 角色.金钱.银子 被吞、只有 baseAmount 生效）：
+ * 提示词让 AI 写旧别名（金元宝/银子/铜钱）与 baseAmount，但归一化与面板都优先认
+ * 三层货币字段（上层/中层/底层货币）。AI 只写别名时，陈旧三层字段会把新值反向覆盖。
+ */
+
+// 测试环境未注入运行时配置，走默认武侠汇率：1 金元宝 = 100 银 = 100000 铜钱价值
+const 构建双重字段金钱 = (overrides: Record<string, number>) => ({
+    上层货币: 0, 中层货币: 3500, 底层货币: 0,
+    金元宝: 0, 银子: 3500, 铜钱: 0,
+    baseAmount: 3500000,
+    ...overrides
+});
+
+describe('提取金钱命令字段', () => {
+    it('识别单字段 set/add/sub 命令与 gameState 前缀', () => {
+        const touched = 提取金钱命令字段([
+            { action: 'set', key: '角色.金钱.银子', value: 6270 },
+            { action: 'add', key: 'gameState.角色.金钱.铜钱', value: 5 },
+            { action: 'sub', key: '角色.金钱.baseAmount', value: 100 },
+            { action: 'set', key: '角色.灵力', value: 10 }
+        ]);
+        expect(touched.has('银子')).toBe(true);
+        expect(touched.has('铜钱')).toBe(true);
+        expect(touched.has('baseAmount')).toBe(true);
+        expect(touched.has('灵力')).toBe(false);
+    });
+
+    it('整对象 set 角色.金钱 时收集 value 内出现过的字段，且跳过货币桶', () => {
+        const touched = 提取金钱命令字段([
+            { action: 'set', key: '角色.金钱', value: { 金元宝: 1, 银子: 2, 铜钱: 3, baseAmount: 100003, 货币桶: { a: {} } } }
+        ]);
+        expect(Array.from(touched).sort()).toEqual(['baseAmount', '金元宝', '银子', '铜钱'].sort());
+    });
+});
+
+describe('同步金钱命令写入（纯函数）', () => {
+    it('客户场景：AI 同时写 银子=6270 与 baseAmount=6270000，旧 中层货币=3500 不得反吞', () => {
+        const money = 构建双重字段金钱({ 银子: 6270, baseAmount: 6270000 });
+        const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['银子', 'baseAmount'])) as any;
+        expect(next.金钱.银子).toBe(6270);
+        expect(next.金钱.中层货币).toBe(6270);
+        expect(next.金钱.baseAmount).toBe(6270000);
+        expect(计算金钱BaseAmount总值(next.金钱)).toBe(6270000);
+    });
+
+    it('只写别名：银子=4000 → 中层货币同步，baseAmount 按三层重算', () => {
+        const money = 构建双重字段金钱({ 银子: 4000 });
+        const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['银子'])) as any;
+        expect(next.金钱.中层货币).toBe(4000);
+        expect(next.金钱.银子).toBe(4000);
+        expect(next.金钱.baseAmount).toBe(4000000);
+    });
+
+    it('只写 baseAmount：分解为三层并同步旧别名', () => {
+        const money = 构建双重字段金钱({ baseAmount: 6270000 });
+        const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['baseAmount'])) as any;
+        expect(next.金钱.上层货币).toBe(62);
+        expect(next.金钱.中层货币).toBe(70);
+        expect(next.金钱.底层货币).toBe(0);
+        expect(next.金钱.金元宝).toBe(62);
+        expect(next.金钱.银子).toBe(70);
+        expect(next.金钱.baseAmount).toBe(6270000);
+        expect(计算金钱BaseAmount总值(next.金钱)).toBe(6270000);
+    });
+
+    it('题材别名（灵石）写入 → 底层货币同步', () => {
+        const money = 构建双重字段金钱({ 灵石: 500 });
+        const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['灵石'])) as any;
+        expect(next.金钱.底层货币).toBe(500);
+        expect(next.金钱.铜钱).toBe(500);
+    });
+
+    it('整对象 set 旧别名结构（无三层字段）→ 三层与 baseAmount 全部补齐一致', () => {
+        const money = { 金元宝: 0, 银子: 6270, 铜钱: 0, baseAmount: 6270000 };
+        const next = 同步金钱命令写入({ 金钱: money } as any, new Set(['金元宝', '银子', '铜钱', 'baseAmount'])) as any;
+        expect(next.金钱.上层货币).toBe(0);
+        expect(next.金钱.中层货币).toBe(6270);
+        expect(next.金钱.底层货币).toBe(0);
+        expect(next.金钱.baseAmount).toBe(6270000);
+    });
+
+    it('AI 未触碰任何金钱字段时原样返回', () => {
+        const money = 构建双重字段金钱({});
+        const role = { 金钱: money };
+        expect(同步金钱命令写入(role, new Set())).toBe(role);
+        expect(同步金钱命令写入(null, new Set(['银子']))).toBeNull();
+    });
+});
+
+// ── 端到端：命令应用 → 写穿透 → 归一化后仍一致 ──────────────────
+const 构建基础状态 = (): 响应命令处理状态 => ({
+    角色: { 姓名: '杨培强' } as any,
+    环境: {} as any,
+    社交: [],
+    世界: {} as any,
+    战斗: {} as any,
+    玩家门派: {} as any,
+    任务列表: [],
+    约定列表: [],
+    剧情: {} as any,
+    剧情规划: {} as any
+});
+
+const deps = {
+    规范化环境信息: (value?: any) => value || {},
+    规范化社交列表,
+    规范化世界状态: (value?: any) => value || {},
+    规范化战斗状态: (value?: any) => value || {},
+    规范化门派状态: (value?: any) => value || {},
+    规范化剧情状态: (value?: any) => value || {},
+    规范化剧情规划状态: (value?: any) => value || {},
+    规范化女主剧情规划状态: (value?: any) => value,
+    规范化同人剧情规划状态: (value?: any) => value,
+    规范化同人女主剧情规划状态: (value?: any) => value,
+    规范化角色物品容器映射: (value?: any) => value || {},
+    战斗结束自动清空: (value?: any) => value || {}
+};
+
+describe('端到端：AI 金钱命令不再被旧三层字段吞掉', () => {
+    it('set 银子=6270 + set baseAmount=6270000 后，三层/别名/baseAmount 三者一致', () => {
+        const state = 构建基础状态();
+        state.角色 = { 姓名: '杨培强', 金钱: 构建双重字段金钱({}) } as any;
+        const result = 执行响应命令处理({
+            logs: [{ sender: '旁白', text: '镖局结了账。' }],
+            tavern_commands: [
+                { action: 'set', key: '角色.金钱.银子', value: 6270 },
+                { action: 'set', key: '角色.金钱.baseAmount', value: 6270000 }
+            ]
+        } as any, state, deps as any, undefined, { applyState: false }) as any;
+        expect(result.角色.金钱.银子).toBe(6270);
+        expect(result.角色.金钱.中层货币).toBe(6270);
+        expect(result.角色.金钱.baseAmount).toBe(6270000);
+    });
+
+    it('AI 只发 set 银子 命令时，面板读取的中层货币同步更新', () => {
+        const state = 构建基础状态();
+        state.角色 = { 姓名: '杨培强', 金钱: 构建双重字段金钱({}) } as any;
+        const result = 执行响应命令处理({
+            logs: [{ sender: '旁白', text: '当铺掌柜数出银两。' }],
+            tavern_commands: [
+                { action: 'set', key: '角色.金钱.银子', value: 4000 }
+            ]
+        } as any, state, deps as any, undefined, { applyState: false }) as any;
+        expect(result.角色.金钱.银子).toBe(4000);
+        expect(result.角色.金钱.中层货币).toBe(4000);
+        expect(result.角色.金钱.baseAmount).toBe(4000000);
+    });
+});

--- a/hooks/useGame/responseCommandProcessor.ts
+++ b/hooks/useGame/responseCommandProcessor.ts
@@ -25,6 +25,7 @@ import { 提取NPC死亡风险命令索引, 状态效果是死亡判定 } from '
 import { 构建体内射精记录, 推进社交孕产状态, 规范化孕产时间 } from '../../utils/reproduction';
 import { 自动增加BaseAmount } from '../../services/auctionHouse';
 import { consumeScriptedMoneyDelta, peekScriptedMoneyDelta } from '../../utils/scriptedMoneyReconciler';
+import { 提取金钱命令字段, 同步金钱命令写入 } from './stateTransforms';
 
 /** 判断是否为具体地点变更命令（多货币汇率系统用） */
 const 是否具体地点变更命令 = (key: string): boolean => {
@@ -1706,6 +1707,14 @@ export const 执行响应命令处理 = (
             fandomStoryPlanBuffer = result.fandomStoryPlan;
             fandomHeroinePlanBuffer = result.fandomHeroinePlan;
         });
+
+        // 金钱命令写穿透：AI 本回合写过的金钱字段为权威，同步三层/旧别名/baseAmount，
+        // 防止随后的金钱归一化用陈旧三层字段把刚写入的别名值反向吞掉
+        // （面板读三层字段、提示词却让 AI 写 金元宝/银子/铜钱 别名，见变量提示词 13 条）
+        const 金钱命令字段 = 提取金钱命令字段(response?.tavern_commands);
+        if (金钱命令字段.size > 0) {
+            charBuffer = 同步金钱命令写入(charBuffer, 金钱命令字段);
+        }
 
         envBuffer = deps.规范化环境信息(envBuffer);
         socialBuffer = deps.规范化社交列表(socialBuffer, { 合并同名: false });

--- a/hooks/useGame/stateTransforms.ts
+++ b/hooks/useGame/stateTransforms.ts
@@ -363,6 +363,21 @@ export const 同步金钱命令写入 = (role: any, touchedFields: Set<string>):
     const mode = (profile?.economy?.currencyDisplayMode as any) || undefined;
     const next: Record<string, unknown> = { ...money };
 
+    // 把存档中已存在的题材货币别名字段（灵石/现金/存款/银两等）对齐到所属层级现值。
+    // 只覆盖已存在的字段、不新增键；否则归一化虽优先读三层，但残留旧别名仍是矛盾数据，
+    // 手动删层字段或后续按别名读数时会复活旧值。
+    const 同步已存在题材别名 = () => {
+        (['上层货币', '中层货币', '底层货币'] as 货币层级键[]).forEach((tier) => {
+            const tierValue = Number(next[tier]);
+            if (!Number.isFinite(tierValue)) return;
+            (题材货币字段别名[tier] || []).forEach((alias) => {
+                if (Object.prototype.hasOwnProperty.call(next, alias)) {
+                    next[alias] = Math.max(0, Math.trunc(tierValue));
+                }
+            });
+        });
+    };
+
     if (touchedTiers.size > 0) {
         touchedTiers.forEach((tier) => {
             const legacyAlias = 货币层级旧别名[tier];
@@ -386,6 +401,7 @@ export const 同步金钱命令写入 = (role: any, touchedFields: Set<string>):
             next[legacyAlias] = value;
         });
         next.baseAmount = 计算角色货币底层总值(next as any, profile, mode);
+        同步已存在题材别名();
     } else if (touchedBaseAmount) {
         const baseValue = Number(next.baseAmount);
         if (!Number.isFinite(baseValue)) return role;
@@ -398,6 +414,7 @@ export const 同步金钱命令写入 = (role: any, touchedFields: Set<string>):
         next.银子 = 分解.银子;
         next.铜钱 = 分解.铜钱;
         next.baseAmount = total;
+        同步已存在题材别名();
     }
     return { ...role, 金钱: next };
 };

--- a/hooks/useGame/stateTransforms.ts
+++ b/hooks/useGame/stateTransforms.ts
@@ -15,7 +15,8 @@ import { 补齐自动丹药预设, 古风丹药预设名称集合, 生存补给�
 import type { ModeRuntimeProfile, 题材模式类型, ExpandedCurrencySystem } from '../../models/system';
 import { 获取展开货币系统 } from '../../utils/apiConfig';
 import { 获取境界配置, 规范化境界显示文本 as 规范化境界显示文本共享, 获取境界层级, 获取境界名称列表 } from '../../utils/realmConfig';
-import { 确保角色金钱BaseAmount, 规范化角色金钱 } from '../../utils/currencyDisplay';
+import { 确保角色金钱BaseAmount, 规范化角色金钱, 题材货币字段别名, 底层总值转角色金钱, 计算角色货币底层总值 } from '../../utils/currencyDisplay';
+import { normalizeStateCommandKey } from '../../utils/stateHelpers';
 import type { 境界配置 } from '../../utils/realmConfig';
 import { NPC调试日志已启用 } from '../../utils/debugFlags';
 
@@ -287,6 +288,120 @@ const 构建背景货币实体物品 = (entry: 背景货币展开结果) => ({
     价值: entry.货币键 === '上层货币' ? 10000 : entry.货币键 === '中层货币' ? 100 : 1,
     词条列表: [],
 } as any);
+const 货币层级旧别名: Record<货币层级键, string> = {
+    上层货币: '金元宝',
+    中层货币: '银子',
+    底层货币: '铜钱'
+};
+
+/** 单个金钱字段 → 所属三层货币层级；非金钱记账字段返回 null。 */
+const 金钱字段所属层级 = (field: string): 货币层级键 | null => {
+    if (field === '上层货币' || field === '中层货币' || field === '底层货币') return field;
+    if (field === '金元宝') return '上层货币';
+    if (field === '银子') return '中层货币';
+    if (field === '铜钱') return '底层货币';
+    for (const [tier, aliases] of Object.entries(题材货币字段别名)) {
+        if ((aliases as string[]).includes(field)) return tier as 货币层级键;
+    }
+    return null;
+};
+
+/**
+ * 提取本回合 AI 命令触碰过的 `角色.金钱.*` 记账字段名。
+ * 整对象 `set 角色.金钱 = {...}` 时收集 value 对象里出现过的字段。
+ */
+export const 提取金钱命令字段 = (commands: unknown): Set<string> => {
+    const touched = new Set<string>();
+    if (!Array.isArray(commands)) return touched;
+    commands.forEach((cmd: any) => {
+        const action = cmd?.action || 'set';
+        if (action !== 'set' && action !== 'add' && action !== 'sub') return;
+        if (typeof cmd?.key !== 'string') return;
+        const normalizedKey = normalizeStateCommandKey(cmd.key);
+        const 单字段匹配 = normalizedKey.match(/^gameState\.角色\.金钱\.([^.[\]]+)$/);
+        if (单字段匹配) {
+            const field = 单字段匹配[1].trim();
+            if (field && field !== '货币桶') touched.add(field);
+            return;
+        }
+        if (normalizedKey === 'gameState.角色.金钱'
+            && cmd?.value && typeof cmd.value === 'object' && !Array.isArray(cmd.value)) {
+            Object.keys(cmd.value).forEach((field) => {
+                if (field !== '货币桶') touched.add(field);
+            });
+        }
+    });
+    return touched;
+};
+
+/**
+ * 金钱命令写穿透同步：
+ * 变量提示词要求 AI 用旧别名（金元宝/银子/铜钱/题材别名）和 baseAmount 记账，
+ * 但归一化读取与左栏/变量面板显示都优先认三层货币字段。AI 只写别名时，陈旧的
+ * 三层字段会在随后的金钱归一化里反向覆盖刚写入的值——玩家反馈的
+ * 「只有 baseAmount 生效、银子被吞回旧值」就是这里来的。
+ * 因此在命令应用后、归一化前，以 AI 本回合写过的字段为权威互相同步：
+ * 写别名/层级 → 层级为权威并重算 baseAmount；只写 baseAmount → 分解为三层。
+ */
+export const 同步金钱命令写入 = (role: any, touchedFields: Set<string>): any => {
+    if (!role || typeof role !== 'object') return role;
+    const money = role.金钱;
+    if (!money || typeof money !== 'object') return role;
+    const touchedTiers = new Set<货币层级键>();
+    let touchedBaseAmount = false;
+    touchedFields.forEach((field) => {
+        if (field === 'baseAmount') {
+            touchedBaseAmount = true;
+            return;
+        }
+        const tier = 金钱字段所属层级(field);
+        if (tier) touchedTiers.add(tier);
+    });
+    if (touchedTiers.size === 0 && !touchedBaseAmount) return role;
+
+    const profile = _当前运行时配置;
+    const mode = (profile?.economy?.currencyDisplayMode as any) || undefined;
+    const next: Record<string, unknown> = { ...money };
+
+    if (touchedTiers.size > 0) {
+        touchedTiers.forEach((tier) => {
+            const legacyAlias = 货币层级旧别名[tier];
+            let value: number | null = null;
+            // AI 本回合写过的别名优先（旧别名在前、题材别名其次），避免陈旧层级字段抢先
+            const aliasCandidates = [legacyAlias, ...(题材货币字段别名[tier] || [])];
+            for (const alias of aliasCandidates) {
+                if (!touchedFields.has(alias)) continue;
+                const aliasValue = Number(next[alias]);
+                if (Number.isFinite(aliasValue)) {
+                    value = Math.max(0, Math.trunc(aliasValue));
+                    break;
+                }
+            }
+            if (value === null && touchedFields.has(tier)) {
+                const directValue = Number(next[tier]);
+                if (Number.isFinite(directValue)) value = Math.max(0, Math.trunc(directValue));
+            }
+            if (value === null) return;
+            next[tier] = value;
+            next[legacyAlias] = value;
+        });
+        next.baseAmount = 计算角色货币底层总值(next as any, profile, mode);
+    } else if (touchedBaseAmount) {
+        const baseValue = Number(next.baseAmount);
+        if (!Number.isFinite(baseValue)) return role;
+        const total = Math.max(0, Math.trunc(baseValue));
+        const 分解 = 底层总值转角色金钱(total, profile, mode);
+        next.上层货币 = 分解.上层货币;
+        next.中层货币 = 分解.中层货币;
+        next.底层货币 = 分解.底层货币;
+        next.金元宝 = 分解.金元宝;
+        next.银子 = 分解.银子;
+        next.铜钱 = 分解.铜钱;
+        next.baseAmount = total;
+    }
+    return { ...role, 金钱: next };
+};
+
 const 从物品列表汇总角色货币 = (items: any[], fallbackMoney: Record<string, number>) => {
     const hasCurrencyItems = items.some((item: any) => {
         const name = 规范化文本(item?.名称);


### PR DESCRIPTION
## 问题背景

玩家反馈（darkvanmaster）：AI 更新钱财时下发了
- `[#2] set 角色.金钱.银子 = 6270`
- `[#3] set 角色.金钱.baseAmount = 6270000`

但**只有 baseAmount 生效**；JSON 里出现/保留了 `"上层货币": 0, "中层货币": 3500, "底层货币": 0`，AI 变量更新不写它们，而面板读取的恰恰是它们——于是银子显示一直卡在旧值 3500。玩家手动删掉 中层/底层货币 再改银子，保存时字段又自动生成（值一致，属归一化补全行为）。与创意工坊预设无关，原版存档同样复现。

## 根因

金钱对象存在**两套并存字段**：三层货币（`上层货币/中层货币/底层货币`）与旧别名（`金元宝/银子/铜钱`）+ `baseAmount`：

1. 变量提示词（`prompts/runtime/variableModel.ts` 第 13 条）要求 AI 「保留 `{ 金元宝, 银子, 铜钱, baseAmount? }` 兼容字段」→ AI 写的是旧别名；
2. 命令应用是通用路径写入，`银子` 更新后陈旧的 `中层货币` 原样保留；
3. 每回合命令应用后 `规范化角色物品容器映射 → 从物品列表汇总角色货币 → 规范化角色金钱` 归一化，`读取货币数值` **优先取三层字段**——`中层货币` 有值（3500）就完全忽略 `银子`，再反向把 `银子` 回写成 3500，AI 刚写的值被吞；
4. `baseAmount` 读取是「有现成值就保留」，所以 baseAmount 命令生效——正好构成玩家看到的症状；
5. 面板（`LeftPanel` / 变量管理）经 `规范化角色金钱` 读三层字段 → 显示旧值。

另外脚本侧（`自动增加BaseAmount`）是「以 baseAmount 为准重算三层」，与归一化的「以三层为准」方向互斥，造成 `baseAmount=6,270,000` 与 `中层货币=3500`（折算 350 万）长期矛盾并存。

## 修复方案

在命令应用后、金钱归一化前，**以 AI 本回合写过的金钱字段为权威做写穿透同步**（与 `scriptedMoneyReconciler` 处理拍卖收入的同一原则）：

- 写别名（金元宝/银子/铜钱/题材别名 灵石/现金/存款…）→ 以写入值为权威同步对应三层字段，并按三层重算 `baseAmount`；
- 直接写三层字段 → 同步旧别名镜像；
- 只写 `baseAmount` → 按货币层级配置分解为三层并同步别名。

新增 `stateTransforms.ts`：
- `提取金钱命令字段`：收集本回合触碰过的 `角色.金钱.*` 记账字段（含 `gameState.` 前缀、整对象 set、跳过 `货币桶`）；
- `同步金钱命令写入`：按上述规则写穿透，复用 `题材货币字段别名` / `底层总值转角色金钱` / `计算角色货币底层总值`。

`responseCommandProcessor.ts` 在 tavern_commands 应用完后调用，位于随后的金钱归一化之前。

## 测试

- 新增 `__tests__/moneyCommandWriteThrough.test.ts`（10 例）：客户原场景（银子+baseAmount 双写）、只写别名、只写 baseAmount 分解、题材别名、整对象 set、未触碰原样返回、端到端两条；
- 既有 `scriptedMoneyReconciliation` / `currencyTopicFields` 等金钱相关测试全部通过；
- `npx vitest run`：2933 通过（失败项均为真实 AI e2e 与 `.release-repo-v634` 本地旧快照目录，与本次改动无关）；
- `npm run build` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复 AI 金钱命令写入后数据未正确同步的问题。
  - 现在修改金元宝、银子、铜钱、灵石及基础金额等字段时，会同步更新对应的三层货币数据。
  - 防止旧的货币字段覆盖最新写入的金额，确保命令处理和最终角色状态保持一致。

- **Tests**
  - 增加金钱命令写入、字段别名、金额增减及端到端处理场景的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->