### PR TITLE
修复白色模式彩色胶囊可读性 + 生成流程图模型名完整显示

### DIFF
--- a/components/features/Settings/NovelDecompositionSettings.tsx
+++ b/components/features/Settings/NovelDecompositionSettings.tsx
@@ -3513,7 +3513,7 @@ const NovelDecompositionSettings: React.FC<Props> = ({ settings, onSave, request
                                             <div className={`text-sm font-medium truncate ${selectedSegment?.id === segment.id ? 'text-wuxia-gold' : 'text-gray-200'}`}>
                                                 {segment.标题 || `分段 ${index + 1}`}
                                             </div>
-                                            <div className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded ${segment.启用注入 === false ? 'bg-gray-800 text-gray-400' : 'bg-emerald-950/50 text-emerald-400'}`}>
+                                            <div className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded ${segment.启用注入 === false ? 'bg-black/50 text-gray-400' : 'bg-emerald-950/50 text-emerald-400'}`}>
                                                 {segment.启用注入 === false ? '注入关' : '注入开'}
                                             </div>
                                         </div>

--- a/components/features/Settings/WorkflowGraphSettings.tsx
+++ b/components/features/Settings/WorkflowGraphSettings.tsx
@@ -662,7 +662,8 @@ const WorkflowGraphSettings: React.FC<{
                     }}
                     disabled={normalized.configs.length === 0 || !onSave}
                     placeholder="选择渠道"
-                    buttonClassName="h-7 min-h-0 rounded-sm border-gray-700 bg-black/35 px-2 py-1 text-[9px] leading-4"
+                    wrapLabel
+                    buttonClassName="min-h-7 rounded-sm border-gray-700 bg-black/35 px-2 py-1 text-[9px] leading-4"
                     panelClassName="text-[10px]"
                     optionClassName="px-2 py-1.5 text-[10px] leading-4"
                 />
@@ -679,7 +680,8 @@ const WorkflowGraphSettings: React.FC<{
                         }}
                         disabled={modelOptions.length === 0 || !onSave}
                         placeholder="选择模型"
-                        buttonClassName="h-7 min-h-0 rounded-sm border-gray-700 bg-black/35 px-2 py-1 text-[9px] leading-4"
+                        wrapLabel
+                        buttonClassName="min-h-7 rounded-sm border-gray-700 bg-black/35 px-2 py-1 text-[9px] leading-4"
                         panelClassName="text-[10px]"
                         optionClassName="px-2 py-1.5 text-[10px] leading-4"
                     />
@@ -809,8 +811,8 @@ const WorkflowGraphSettings: React.FC<{
                 </div>
             )}
             <div className="mt-1 space-y-0.5 text-[10px] leading-4">
-                <div className="truncate text-gray-300">渠道：<span className="text-wuxia-cyan">{stage.channel}</span></div>
-                <div className="truncate text-gray-300">模型：<span className="text-wuxia-gold">{stage.model}</span></div>
+                <div className="break-all text-gray-300">渠道：<span className="text-wuxia-cyan">{stage.channel}</span></div>
+                <div className="break-all text-gray-300">模型：<span className="text-wuxia-gold">{stage.model}</span></div>
                 {stageInlineSelector(stage)}
                 <div className="text-gray-500">{stage.note}</div>
                 {clickable && (

--- a/components/ui/InlineSelect.tsx
+++ b/components/ui/InlineSelect.tsx
@@ -14,6 +14,8 @@ type InlineSelectProps<T extends string = string> = {
     buttonClassName?: string;
     panelClassName?: string;
     optionClassName?: string;
+    /** Label wraps onto multiple lines instead of being truncated with an ellipsis. */
+    wrapLabel?: boolean;
 };
 
 const InlineSelect = <T extends string>({
@@ -24,7 +26,8 @@ const InlineSelect = <T extends string>({
     disabled = false,
     buttonClassName = '',
     panelClassName = '',
-    optionClassName = ''
+    optionClassName = '',
+    wrapLabel = false
 }: InlineSelectProps<T>) => {
     const [open, setOpen] = useState(false);
     const rootRef = useRef<HTMLDivElement | null>(null);
@@ -73,7 +76,7 @@ const InlineSelect = <T extends string>({
                             : 'bg-black/40 border-gray-600 text-white hover:border-gray-500')
                 } ${buttonClassName}`}
             >
-                <span className={`truncate ${selected ? '' : 'text-gray-400'}`}>
+                <span className={`${wrapLabel ? 'whitespace-normal break-all text-left' : 'truncate'} ${selected ? '' : 'text-gray-400'}`}>
                     {selected?.label || placeholder}
                 </span>
                 <svg
@@ -114,7 +117,7 @@ const InlineSelect = <T extends string>({
                                             : 'text-gray-200 hover:bg-white/5'
                                     }`}
                                 >
-                                    <span className="truncate">{option.label}</span>
+                                    <span className={wrapLabel ? 'whitespace-normal break-all' : 'truncate'}>{option.label}</span>
                                     {active && <span className="text-[10px] text-wuxia-gold/80 shrink-0">当前</span>}
                                 </button>
                             );

--- a/styles/global.css
+++ b/styles/global.css
@@ -234,6 +234,25 @@ html[data-theme="day"] [class*="to-ink-black"] {
   background-color: rgb(var(--c-ink-black)) !important;
 }
 
+/* Day mode: emerald/green and indigo/purple-family colored backgrounds were
+   missing from the tint rules above, so their dark chips (bg-*-950/xx, e.g. the
+   tavern preset status badge) kept a dark fill while the text rules darkened
+   the light text, producing dark-on-dark chips. Give them the same light
+   tint treatment as the amber/cyan/red rules. */
+html[data-theme="day"] [class*="bg-emerald-"],
+html[data-theme="day"] [class*="bg-green-"],
+html[data-theme="day"] [class*="bg-lime-"] {
+  background-color: rgba(22, 101, 52, 0.10) !important;
+}
+
+html[data-theme="day"] [class*="bg-indigo-"],
+html[data-theme="day"] [class*="bg-violet-"],
+html[data-theme="day"] [class*="bg-purple-"],
+html[data-theme="day"] [class*="bg-fuchsia-"],
+html[data-theme="day"] [class*="bg-pink-"] {
+  background-color: rgba(134, 25, 143, 0.10) !important;
+}
+
 html[data-theme="day"] [class*="text-white"],
 html[data-theme="day"] [class*="text-gray-100"],
 html[data-theme="day"] [class*="text-gray-200"],


### PR DESCRIPTION
## 问题

1. **白色（日间）模式下部分状态胶囊完全看不清**：酒馆预设状态徽章等使用 `bg-emerald-950/75 + text-emerald-100` 的深底浅字组合，日间主题的全局换色规则把浅色字翻成深墨色、但 emerald/green 与 indigo/violet/purple/fuchsia/pink 色系的深底没有对应浅染规则，形成深底深字。
2. **生成流程图模型/渠道名称被省略号截断**：卡片里“渠道：/模型：”文字行与两个内联下拉（渠道、模型）都按单行 truncate 显示，长模型名看不全。

## 修复

- `styles/global.css`：按既有 amber/cyan/red 规则同款式，补齐 emerald/green/lime 与 indigo/violet/purple/fuchsia/pink 两组色系浅染规则（10% 同色墨色淡染）。顺带修复同一模式下的图片迁移通知条、通知 toast、武功/社交/物品管理等页面的绿紫系标签。规则插入位置在 `.app-play-mode-badge` 专属米纸底规则之前，该徽章外观不变。
- `NovelDecompositionSettings.tsx`："注入关"标签 `bg-gray-800` → `bg-black/50`（灰系不属于彩色规则，单独处理，日间走既有米纸底翻转）。
- `InlineSelect.tsx`：新增可选 `wrapLabel` 属性（选中值与下拉选项 `whitespace-normal break-all` 换行），默认关闭，其他设置页行为不变。
- `WorkflowGraphSettings.tsx`：渠道/模型文字行 `truncate` → `break-all`；两个内联下拉传 `wrapLabel` 并把固定高度 `h-7` 改为 `min-h-7`。

## 验证

- `npm run build` 通过，发布元数据无 diff。
- 本地 dist 预览 + Playwright（2560 视口、day 主题）实测：
  - 13 种彩色深底组合计算对比度 5.35 ~ 12.03:1（WCAG AA 4.5:1）；
  - `app-play-mode-badge` 仍为米纸底 + 深绿字，无回归；
  - 真实存档进入游戏界面，酒馆预设徽章（绿）清晰可读（截图确认）；
  - 注入超长模型名后，流程图文字行、收起下拉、展开面板选项均完整换行显示，无省略号。

## 备注

本次为纯前端展示修复，不改任何游戏逻辑与 API。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 优化工作流图设置中的渠道和模型选择器，较长文本现在可自动换行显示。
  * 调整选择器按钮高度，提升多行内容下的显示效果。
  * 优化“注入关”状态徽章的背景外观。
  * 改善日间主题下绿色与紫色系背景的显示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->