### PR TITLE
修复 Gemini 系模型开局报 400：请求不能以 model 回合结尾

### DIFF
--- a/__tests__/chatCompletionClient.test.ts
+++ b/__tests__/chatCompletionClient.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { __测试__清除已触发上下文截断警告, 应用Claude兼容末尾User修正, 请求模型文本, 是否流式连接中断错误消息, 规范化流式连接错误提示, 规范化请求模型名称, type 通用消息 } from '../services/ai/chatCompletionClient';
+import { __测试__清除已触发上下文截断警告, 应用Claude兼容末尾User修正, 应用Gemini尾部Model回合修正, 是否Gemini系模型, 请求模型文本, 是否流式连接中断错误消息, 规范化流式连接错误提示, 规范化请求模型名称, type 通用消息 } from '../services/ai/chatCompletionClient';
 import type { 当前可用接口结构 } from '../utils/apiConfig';
 
 const baseConfig: 当前可用接口结构 = {
@@ -505,5 +505,86 @@ describe('chatCompletionClient Claude compatible message normalization', () => {
         expect(是否流式连接中断错误消息(raw)).toBe(true);
         expect(规范化流式连接错误提示(raw)).toContain('模型流式连接中途断开');
         expect(规范化流式连接错误提示(raw)).not.toContain('com.android.okhttp.Address');
+    });
+});
+
+describe('chatCompletionClient Gemini trailing model turn normalization', () => {
+    afterEach(() => {
+        __测试__清除已触发上下文截断警告();
+        vi.restoreAllMocks();
+    });
+
+    it('converts trailing CoT pseudo-history assistant turn into a continuation user turn for Gemini models', () => {
+        const pseudoHistory = '<think>\n思考已结束\n</think>\n好的，将先以<thinking></thinking>输出思考：';
+        const messages: 通用消息[] = [
+            { role: 'system', content: '规则' },
+            { role: 'user', content: '生成世界观' },
+            { role: 'assistant', content: pseudoHistory }
+        ];
+
+        const normalized = 应用Gemini尾部Model回合修正(messages, {
+            ...baseConfig,
+            model: 'gemini-3.6-flash-high'
+        });
+
+        expect(normalized).toHaveLength(3);
+        expect(normalized.at(-1)?.role).toBe('user');
+        expect(normalized.at(-1)?.content).toContain('【续写基准】');
+        expect(normalized.at(-1)?.content).toContain(pseudoHistory);
+        expect(normalized[1].role).toBe('user');
+        expect(normalized.some(msg => msg.role === 'assistant')).toBe(false);
+    });
+
+    it('keeps explicit prefix assistant turns untouched for Gemini models', () => {
+        const messages: 通用消息[] = [
+            { role: 'user', content: '继续' },
+            { role: 'assistant', content: '<thinking>\n', prefix: true }
+        ];
+
+        expect(应用Gemini尾部Model回合修正(messages, { ...baseConfig, model: 'gemini-3.6-flash-high' })).toBe(messages);
+    });
+
+    it('leaves non-Gemini models unchanged', () => {
+        const messages: 通用消息[] = [
+            { role: 'user', content: '生成世界观' },
+            { role: 'assistant', content: '伪历史' }
+        ];
+
+        expect(应用Gemini尾部Model回合修正(messages, { ...baseConfig, model: 'gpt-4.1' })).toBe(messages);
+    });
+
+    it('folds multiple trailing assistant turns into one continuation note', () => {
+        const messages: 通用消息[] = [
+            { role: 'user', content: '开局' },
+            { role: 'assistant', content: '开场一' },
+            { role: 'assistant', content: '开场二' }
+        ];
+
+        const normalized = 应用Gemini尾部Model回合修正(messages, {
+            ...baseConfig,
+            model: '流式抗截断/gemini-3.1-pro-preview'
+        });
+
+        expect(normalized).toHaveLength(2);
+        expect(normalized.at(-1)?.role).toBe('user');
+        expect(normalized.at(-1)?.content).toContain('开场一');
+        expect(normalized.at(-1)?.content).toContain('开场二');
+    });
+
+    it('synthesizes a user turn when only a trailing assistant exists', () => {
+        const normalized = 应用Gemini尾部Model回合修正(
+            [{ role: 'assistant', content: '开场' }],
+            { ...baseConfig, model: 'gemini-3.6-flash-high' }
+        );
+
+        expect(normalized).toHaveLength(1);
+        expect(normalized[0].role).toBe('user');
+        expect(normalized[0].content).toContain('开场');
+    });
+
+    it('detects gemini models behind supplier prefixes', () => {
+        expect(是否Gemini系模型('gemini-3.6-flash-high')).toBe(true);
+        expect(是否Gemini系模型('流式抗截断/gemini-3.1-pro-preview')).toBe(true);
+        expect(是否Gemini系模型('deepseek-v4-pro')).toBe(false);
     });
 });

--- a/__tests__/chatCompletionClient.test.ts
+++ b/__tests__/chatCompletionClient.test.ts
@@ -582,6 +582,21 @@ describe('chatCompletionClient Gemini trailing model turn normalization', () => 
         expect(normalized[0].content).toContain('开场');
     });
 
+    it('drops whitespace-only trailing assistant turns instead of returning the original sequence', () => {
+        const messages: 通用消息[] = [
+            { role: 'user', content: '生成世界观' },
+            { role: 'assistant', content: '   ' }
+        ];
+
+        const normalized = 应用Gemini尾部Model回合修正(messages, {
+            ...baseConfig,
+            model: 'gemini-3.6-flash-high'
+        });
+
+        expect(normalized).toHaveLength(1);
+        expect(normalized[0].role).toBe('user');
+    });
+
     it('detects gemini models behind supplier prefixes', () => {
         expect(是否Gemini系模型('gemini-3.6-flash-high')).toBe(true);
         expect(是否Gemini系模型('流式抗截断/gemini-3.1-pro-preview')).toBe(true);

--- a/services/ai/chatCompletionClient.ts
+++ b/services/ai/chatCompletionClient.ts
@@ -250,6 +250,40 @@ const 解析请求协议类型 = (apiConfig: 当前可用接口结构): 请求�
     return 'openai';
 };
 
+export const 是否Gemini系模型 = (model: string): boolean => /gemini/i.test(标准化模型名(model));
+
+// Gemini 原生 API 不允许请求以 model 回合结尾（400: Requests ending with a model turn
+// are not supported）。开局各阶段（世界观/境界/变量等）会在消息尾部追加 CoT 伪装历史
+// assistant 回合做格式预填充，DeepSeek/GLM 协议各自有清理或原生支持，openai 协议需要
+// 这里兜底：弹出尾部非 prefix 的 assistant，转换为"续写基准"user 回合收尾。
+export const 应用Gemini尾部Model回合修正 = (
+    messages: 通用消息[],
+    apiConfig: 当前可用接口结构
+): 通用消息[] => {
+    if (解析请求协议类型(apiConfig) !== 'openai') return messages;
+    if (!是否Gemini系模型(apiConfig.model)) return messages;
+    const normalized = [...messages];
+    const trailingAssistant: string[] = [];
+    while (normalized.length > 0) {
+        const tail = normalized[normalized.length - 1];
+        if (tail.role !== 'assistant' || tail.prefix === true) break;
+        const content = tail.content.trim();
+        if (content) trailingAssistant.unshift(content);
+        normalized.pop();
+    }
+    if (trailingAssistant.length === 0) return messages;
+    const anchor = trailingAssistant.join('\n\n');
+    normalized.push({
+        role: 'user',
+        content: [
+            '【续写基准】你在上文已经确认了如下的输出开场与格式约定：',
+            anchor,
+            '请把它当作你已经说过的话，直接从这里继续输出完整回复；不要重复这段开场文字，也不要改变既定输出格式。'
+        ].join('\n')
+    });
+    return normalized;
+};
+
 const 读取自定义最大输出Token = (apiConfig: 当前可用接口结构): number | undefined => {
     const raw = apiConfig.maxTokens;
     if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) {
@@ -1888,12 +1922,15 @@ export const 请求模型文本 = async (
         ? requestedResponseFormat
         : undefined;
     const normalizedMessages = 应用Claude兼容末尾User修正(
-        应用GLM消息兼容修正(
-            应用DeepSeek消息兼容修正(
-                应用强制JSON消息修正(messages, effectiveResponseFormat),
+        应用Gemini尾部Model回合修正(
+            应用GLM消息兼容修正(
+                应用DeepSeek消息兼容修正(
+                    应用强制JSON消息修正(messages, effectiveResponseFormat),
+                    protocol
+                ),
                 protocol
             ),
-            protocol
+            apiConfig
         ),
         apiConfig
     );

--- a/services/ai/chatCompletionClient.ts
+++ b/services/ai/chatCompletionClient.ts
@@ -264,14 +264,19 @@ export const 应用Gemini尾部Model回合修正 = (
     if (!是否Gemini系模型(apiConfig.model)) return messages;
     const normalized = [...messages];
     const trailingAssistant: string[] = [];
+    let removedTrailingAssistant = false;
     while (normalized.length > 0) {
         const tail = normalized[normalized.length - 1];
         if (tail.role !== 'assistant' || tail.prefix === true) break;
         const content = tail.content.trim();
         if (content) trailingAssistant.unshift(content);
         normalized.pop();
+        removedTrailingAssistant = true;
     }
-    if (trailingAssistant.length === 0) return messages;
+    // 空白 assistant 尾回合虽不产生续写基准，但同样必须从请求中移除，
+    // 否则 Gemini 仍会收到以 model 回合结尾的请求。
+    if (!removedTrailingAssistant) return messages;
+    if (trailingAssistant.length === 0) return normalized;
     const anchor = trailingAssistant.join('\n\n');
     normalized.push({
         role: 'user',


### PR DESCRIPTION
## 问题（诊断编号 diag_20260829135611_f209046b48437a693c9598e2）

玩家开局报错：

```
[开局生成失败] API Error: 400 - Requests ending with a model turn are not supported. (INVALID_ARGUMENT)
```

失败阶段是**开局世界观生成**，请求走 `ai.bacon123.eu.org/antigravity/v1` + `gemini-3.6-flash-high`（OpenAI 兼容桥接直通 Gemini 原生）。

## 根因

开局各阶段（世界观/境界/变量/小说拆分等，`services/ai/storyTasks.ts` 共 9 处）在消息尾部追加 **CoT 伪装历史 assistant 回合**做格式预填充（`<think>思考已结束</think>好的，将先以<thinking>…输出：`）：

- DeepSeek 原生 / GLM 协议：各自的消息修正会移除尾部非 prefix assistant，或原生支持 prefill → 正常；
- **openai 协议没有任何清理** → 尾部 assistant 原样出站 → Gemini 桥接转成尾部 `role: "model"` 回合 → Gemini 原生 400。

此前用户使用 DeepSeek/GLM/宽容型中转未触发；切到 Gemini 直通渠道后必现。

## 修复

`services/ai/chatCompletionClient.ts`（公共链路 `请求模型文本`，流式/非流式共用）：

- 新增 `是否Gemini系模型`（模型名标准化后 /gemini/i，兼容「流式抗截断/gemini-…」供应商前缀）；
- 新增 `应用Gemini尾部Model回合修正`：仅 **openai 协议 + Gemini 系模型** 时生效——弹出尾部非 `prefix` 的 assistant 回合，转换为「【续写基准】…请直接从这里继续输出」的 user 回合收尾，既满足 Gemini「不能以 model 回合结尾」的约束，又保留伪历史的格式锚定意图；
- 显式 `prefix: true` 的预填充（DeepSeek 锁格式/GLM 前缀模式）不受影响；deepseek/glm 协议行为完全不变。

## 测试

`__tests__/chatCompletionClient.test.ts` 新增 6 例：尾部伪历史转换、prefix 不动、非 Gemini 不动（保持原引用）、多条尾部 assistant 合并、仅 assistant 时合成 user、供应商前缀下的模型识别。文件 37 例全部通过；`npm run build` 通过，发布元数据无 diff。

## 影响面

仅影响「openai 协议 + Gemini 系模型」的请求消息形态（尾部 assistant → user 续写基准）；其余协议/模型零行为变化。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化 Gemini 系列模型的对话续写处理，减少因历史回复格式导致的生成异常。
  * 自动整理对话末尾的连续模型回复，并转换为更适合续写的上下文提示。
  * 保留明确标记的回复内容，确保已有续写场景不受影响。
  * 非 Gemini 模型的对话行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->