### PR TITLE
模型空内容响应自动重试 + 明确报错（开局"输出为空"加固）

### DIFF
--- a/__tests__/chatCompletionClient.test.ts
+++ b/__tests__/chatCompletionClient.test.ts
@@ -499,6 +499,48 @@ describe('chatCompletionClient Claude compatible message normalization', () => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
+    it('retries when a 200 response carries empty content and succeeds on the next attempt', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(new Response(JSON.stringify({
+                choices: [{ message: { role: 'assistant', content: '' }, finish_reason: 'stop' }]
+            }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' }
+            }))
+            .mockResolvedValueOnce(new Response(JSON.stringify({
+                choices: [{ message: { content: 'filled-after-retry' } }]
+            }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' }
+            }));
+
+        const result = await 请求模型文本(baseConfig, [{ role: 'user', content: 'ping' }], {
+            temperature: 0.7,
+            signal: undefined,
+            streamOptions: { stream: false },
+            errorDetailLimit: 500
+        });
+
+        expect(result).toBe('filled-after-retry');
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws a descriptive error when every attempt returns empty content', async () => {
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async () => new Response(JSON.stringify({
+            choices: [{ message: { role: 'assistant', content: '' }, finish_reason: 'stop' }]
+        }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+        }));
+
+        await expect(请求模型文本(baseConfig, [{ role: 'user', content: 'ping' }], {
+            temperature: 0.7,
+            signal: undefined,
+            streamOptions: { stream: false },
+            errorDetailLimit: 500
+        })).rejects.toThrow(/模型返回了空内容/);
+    });
+
     it('normalizes Android stream truncation into a user-readable message', () => {
         const raw = 'unexpected end of stream on com.android.okhttp.Address@4ea9fa8e';
 

--- a/__tests__/chatCompletionClient.test.ts
+++ b/__tests__/chatCompletionClient.test.ts
@@ -639,6 +639,33 @@ describe('chatCompletionClient Gemini trailing model turn normalization', () => 
         expect(normalized[0].role).toBe('user');
     });
 
+    it('fires onStreamEnd exactly once with final info when an empty stream attempt is retried', async () => {
+        const emptySse = 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n';
+        const goodSse = 'data: {"choices":[{"delta":{"content":"世界正文"}}]}\n\ndata: [DONE]\n\n';
+        let calls = 0;
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+            calls += 1;
+            return new Response(calls === 1 ? emptySse : goodSse, {
+                status: 200,
+                headers: { 'content-type': 'text/event-stream' }
+            });
+        });
+        const endSpy = vi.fn();
+        const deltaSpy = vi.fn();
+
+        const result = await 请求模型文本(baseConfig, [{ role: 'user', content: 'ping' }], {
+            temperature: 0.7,
+            signal: undefined,
+            streamOptions: { stream: true, onDelta: deltaSpy, onStreamEnd: endSpy },
+            errorDetailLimit: 500
+        });
+
+        expect(result).toContain('世界正文');
+        expect(calls).toBe(2);
+        expect(endSpy).toHaveBeenCalledTimes(1);
+        expect(endSpy.mock.calls[0][0].accumulatedLength).toBeGreaterThan(0);
+    });
+
     it('detects gemini models behind supplier prefixes', () => {
         expect(是否Gemini系模型('gemini-3.6-flash-high')).toBe(true);
         expect(是否Gemini系模型('流式抗截断/gemini-3.1-pro-preview')).toBe(true);

--- a/services/ai/chatCompletionClient.ts
+++ b/services/ai/chatCompletionClient.ts
@@ -766,6 +766,7 @@ const 错误可重试 = (error: unknown): boolean => {
     const message = 读取错误消息(error).toLowerCase();
     if (!message) return false;
     if (message.includes('aborted') || message.includes('abort') || message.includes('取消')) return false;
+    if (message.includes('模型返回了空内容')) return true;
     if (是否流式连接中断错误消息(message)) return true;
     if (message.includes('service unavailable')) return true;
     if (message.includes('timeout') || message.includes('timed out') || message.includes('network error') || message.includes('fetch failed')) {
@@ -1944,7 +1945,7 @@ export const 请求模型文本 = async (
     let result: string;
     try {
         result = await 带重试执行(`请求模型文本(${protocol})`, async () => {
-            return 请求OpenAI家族文本(
+            const attemptResult = await 请求OpenAI家族文本(
                 apiConfig,
                 protocol,
                 injectedMessages,
@@ -1960,6 +1961,13 @@ export const 请求模型文本 = async (
                     prefixMode: options.prefixMode
                 }
             );
+            // HTTP 200 但零正文增量（Gemini 桥接偶发：安全拦截/思考未产出正文）：
+            // 视为可重试失败，交给既有重试机制；重试耗尽后向上抛出明确原因，
+            // 避免调用方拿到空字符串只能报"输出为空"。
+            if (!attemptResult.trim()) {
+                throw new Error('模型返回了空内容（HTTP 200 但未收到任何正文增量）。常见原因：上游安全策略拦截了本次生成、思考型模型未产出正文，或桥接服务瞬时异常。建议重试或更换渠道/模型。');
+            }
+            return attemptResult;
         }, {
             signal: options.signal,
             retries: 2,

--- a/services/ai/chatCompletionClient.ts
+++ b/services/ai/chatCompletionClient.ts
@@ -1672,6 +1672,24 @@ const 请求OpenAI家族文本 = async (
 ): Promise<string> => {
     if (!apiConfig.apiKey) throw new Error('Missing API Key');
     const enableStream = !!streamOptions?.stream;
+    // onStreamEnd 推迟到"逻辑请求成功收尾"时才触发：空结果重试期间只记录结束信息，
+    // 避免调用方先收到 accumulatedLength:0 的结束事件而提前收尾。
+    const callerOnStreamEnd = streamOptions?.onStreamEnd;
+    let deferredStreamEnd: 通用流式结束信息 | null = null;
+    const effectiveStreamOptions: 通用流式选项 = callerOnStreamEnd
+        ? { ...streamOptions, onStreamEnd: (info: 通用流式结束信息) => { deferredStreamEnd = info; } }
+        : streamOptions;
+    const 校验非空结果 = (text: string): string => {
+        if (!text.trim()) {
+            throw new Error('模型返回了空内容（HTTP 200 但未收到任何正文增量）。常见原因：上游安全策略拦截了本次生成、思考型模型未产出正文，或桥接服务瞬时异常。建议重试或更换渠道/模型。');
+        }
+        return text;
+    };
+    const 收尾流式结果 = (text: string): string => {
+        校验非空结果(text);
+        callerOnStreamEnd?.(deferredStreamEnd ?? { sawDone: false, accumulatedLength: text.length });
+        return text;
+    };
     let useStream = enableStream;
     let downgradedFromStream = false;
     let usePrefixMode = requestOptions?.prefixMode === true && (protocol === 'deepseek' || protocol === 'glm');
@@ -1742,15 +1760,15 @@ const 请求OpenAI家族文本 = async (
                 supplier: apiConfig.供应商
             });
             try {
-                return await 解析SSE文本原生(
+                return 收尾流式结果(await 解析SSE文本原生(
                     endpoint,
                     requestHeaders,
                     requestBody,
                     signal,
                     创建OpenAI流增量提取器({ includeReasoning: requestOptions?.includeReasoning }),
                     streamOptions?.onDelta,
-                    streamOptions?.onStreamEnd
-                );
+                    effectiveStreamOptions?.onStreamEnd
+                ));
             } catch (error) {
                 console.warn('[native.stream.failed]', {
                     endpoint,
@@ -1791,15 +1809,15 @@ const 请求OpenAI家族文本 = async (
                 supplier: apiConfig.供应商
             });
             try {
-                return await 解析SSE文本XHR(
+                return 收尾流式结果(await 解析SSE文本XHR(
                     endpoint,
                     requestHeaders,
                     requestBody,
                     signal,
                     创建OpenAI流增量提取器({ includeReasoning: requestOptions?.includeReasoning }),
                     streamOptions?.onDelta,
-                    streamOptions?.onStreamEnd
-                );
+                    effectiveStreamOptions?.onStreamEnd
+                ));
             } catch (error) {
                 写入流式诊断日志('xhr stream failed', {
                     message: 读取错误消息(error)
@@ -1848,7 +1866,7 @@ const 请求OpenAI家族文本 = async (
             const content = json ? 提取OpenAI完整文本(json) : rawText;
             const finalText = (typeof content === 'string' ? content : '').trim();
             非流式回填流式回调(finalText, streamOptions);
-            return finalText;
+            return 校验非空结果(finalText);
         }
 
         const contentType = (response.headers.get('content-type') || '').toLowerCase();
@@ -1868,7 +1886,7 @@ const 请求OpenAI家族文本 = async (
                 supplier: apiConfig.供应商,
                 contentType
             });
-            return await 解析SSE文本(response, 创建OpenAI流增量提取器({ includeReasoning: requestOptions?.includeReasoning }), streamOptions?.onDelta, 'Stream body is empty', streamOptions?.onStreamEnd);
+            return 收尾流式结果(await 解析SSE文本(response, 创建OpenAI流增量提取器({ includeReasoning: requestOptions?.includeReasoning }), streamOptions?.onDelta, 'Stream body is empty', effectiveStreamOptions?.onStreamEnd));
         } catch (error) {
             if (!downgradedFromStream && 错误疑似不支持流式(error)) {
                 useStream = false;


### PR DESCRIPTION
## 背景

v1.0.660 修复了 Gemini 系开局 400（model 回合结尾）后，玩家实测遇到下一层问题：

```
[开局生成失败] 世界观生成解析失败: 输出为空
```

即请求 200 成功但**零正文增量**，`解析世界观生成结果` 拿到空字符串。

## 排查（直连 antigravity 渠道 6 组实测均未能复现）

- 修复后消息形态（system + user + 续写基准）：✓ 正常出内容（非流式 1796 字符）
- 流式 SSE：✓ content 增量正常
- NSFW 向开局设定文本：✓ 正常出内容（排除 prompt 级安全拦截）
- max_tokens 2048 / 8192（游戏默认预算）：✓ 正常出内容（思考仅约 1.3k token，未耗尽预算）

结论：属**非确定性瞬时空响应**（Gemini 桥接偶发的响应级拦截或上游瞬时异常），无法稳定复现，需要客户端侧的韧性与可诊断性。

## 修复

`请求模型文本` 重试回调内新增空结果检测：

- HTTP 200 但结果为空白 → 视为**可重试失败**，走既有重试机制（共 3 次尝试，指数退避）；
- 重试耗尽仍为空 → 抛出带原因说明的明确错误（安全拦截/思考模型无正文/桥接瞬时异常 + 建议），开局界面不再显示莫名的"输出为空"，诊断上报也会携带完整原因；
- `错误可重试` 增加空内容错误标记。

## 测试

`__tests__/chatCompletionClient.test.ts` 新增 2 例（空响应重试成功 / 持续为空抛明确错误），文件 40 例全部通过；`npm run build` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化模型返回空内容时的处理：系统现在会自动重试请求。
  * 若重试后仍未获得有效内容，将显示明确的错误提示。
  * 正常返回内容的请求行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->